### PR TITLE
publish the orientation into tf

### DIFF
--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
@@ -31,6 +31,7 @@
 #include <sensor_msgs/Imu.h>
 #include <geometry_msgs/Vector3Stamped.h>
 #include <tf/transform_datatypes.h>
+#include <tf/transform_broadcaster.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
@@ -62,12 +63,14 @@ class ImuFilter
     boost::shared_ptr<MagSubscriber> mag_subscriber_;
 
     ros::Publisher imu_publisher_;
+    tf::TransformBroadcaster tf_broadcaster_;
   
     // **** paramaters
 
     double gain_;				// algorithm gain
     bool use_mag_;
     std::string fixed_frame_;
+    std::string tf_prefix_;
     double constant_dt_;
 
 
@@ -85,6 +88,7 @@ class ImuFilter
     void imuCallback(const ImuMsg::ConstPtr& imu_msg_raw);
 
     void publishFilteredMsg(const ImuMsg::ConstPtr& imu_msg_raw);
+    void publishTransform(void);
 
     void madgwickAHRSupdate(float gx, float gy, float gz, 
                             float ax, float ay, float az, 

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
@@ -70,9 +70,8 @@ class ImuFilter
     double gain_;				// algorithm gain
     bool use_mag_;
     std::string fixed_frame_;
-    std::string tf_prefix_;
+    std::string imu_frame_;
     double constant_dt_;
-
 
     // **** state variables
   


### PR DESCRIPTION
Hello-- I added a bit which publishes a transform from the frame in which the filter publishes the orientation back into the frame of the imu itself. I needed this because I want the zero orientation to be level and pointing north, but when the magnetic field shows a declination then the orentation that the filter publishes is in the frame of the magnetic field. So, combined with a transform (published elsewhere) from the world frame into the magnetic field frame, I now have a transform from the imu frame back into the world frame.

Best
-s
