### PR TITLE
replace invSqrt() with 1/sqrt()

### DIFF
--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
@@ -111,19 +111,6 @@ class ImuFilter
                                float dt);
 
     void reconfigCallback(FilterConfig& config, uint32_t level);
-    
-    // Fast inverse square-root
-    // See: http://en.wikipedia.org/wiki/Fast_inverse_square_root
-    static float invSqrt(float x) 
-    {
-      float halfx = 0.5f * x;
-      float y = x;
-      long i = *(long*)&y;
-      i = 0x5f3759df - (i>>1);
-      y = *(float*)&i;
-      y = y * (1.5f - (halfx * y * y));
-      return y;
-    }
 };
 
 #endif // IMU_FILTER_IMU_MADWICK_FILTER_H

--- a/imu_filter_madgwick/src/imu_filter.cpp
+++ b/imu_filter_madgwick/src/imu_filter.cpp
@@ -238,7 +238,7 @@ void ImuFilter::madgwickAHRSupdate(
   float mx, float my, float mz, 
   float dt)
 {
-	float recipNorm;
+	float norm, recipNorm;
 	float s0, s1, s2, s3;
 	float qDot1, qDot2, qDot3, qDot4;
 	float hx, hy;
@@ -257,13 +257,17 @@ void ImuFilter::madgwickAHRSupdate(
 	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) 
   {
 		// Normalise accelerometer measurement
-		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
+		norm = sqrt(ax * ax + ay * ay + az * az);
+		if (norm == 0.0f) return;   // handle NaN
+		recipNorm = 1 / norm;       // use reciprocal for division
 		ax *= recipNorm;
 		ay *= recipNorm;
-		az *= recipNorm;   
+		az *= recipNorm;
 
 		// Normalise magnetometer measurement
-		recipNorm = invSqrt(mx * mx + my * my + mz * mz);
+		norm = sqrt(mx * mx + my * my + mz * mz);
+		if (norm == 0.0f) return;   // handle NaN
+		recipNorm = 1 / norm;       // use reciprocal for division
 		mx *= recipNorm;
 		my *= recipNorm;
 		mz *= recipNorm;
@@ -303,7 +307,7 @@ void ImuFilter::madgwickAHRSupdate(
 		s1 = _2q3 * (2.0f * q1q3 - _2q0q2 - ax) + _2q0 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q1 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + _2bz * q3 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q2 + _2bz * q0) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q3 - _4bz * q1) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
 		s2 = -_2q0 * (2.0f * q1q3 - _2q0q2 - ax) + _2q3 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q2 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + (-_4bx * q2 - _2bz * q0) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q1 + _2bz * q3) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q0 - _4bz * q2) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
 		s3 = _2q1 * (2.0f * q1q3 - _2q0q2 - ax) + _2q2 * (2.0f * q0q1 + _2q2q3 - ay) + (-_4bx * q3 + _2bz * q1) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q0 + _2bz * q2) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q1 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
+		recipNorm = 1.0f / sqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
 		s0 *= recipNorm;
 		s1 *= recipNorm;
 		s2 *= recipNorm;
@@ -348,7 +352,7 @@ void ImuFilter::madgwickAHRSupdate(
 	q3 += qDot4 * dt;
 
 	// Normalise quaternion
-	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+	recipNorm = 1.0f / sqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
 	q0 *= recipNorm;
 	q1 *= recipNorm;
 	q2 *= recipNorm;
@@ -376,7 +380,7 @@ void ImuFilter::madgwickAHRSupdateIMU(
 	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) 
   {
 		// Normalise accelerometer measurement
-		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
+		recipNorm = 1.0f / sqrt(ax * ax + ay * ay + az * az);
 		ax *= recipNorm;
 		ay *= recipNorm;
 		az *= recipNorm;   
@@ -401,7 +405,7 @@ void ImuFilter::madgwickAHRSupdateIMU(
 		s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1 - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
 		s2 = 4.0f * q0q0 * q2 + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
 		s3 = 4.0f * q1q1 * q3 - _2q1 * ax + 4.0f * q2q2 * q3 - _2q2 * ay;
-		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
+		recipNorm = 1.0f / sqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
 		s0 *= recipNorm;
 		s1 *= recipNorm;
 		s2 *= recipNorm;
@@ -421,7 +425,7 @@ void ImuFilter::madgwickAHRSupdateIMU(
 	q3 += qDot4 * dt;
 
 	// Normalise quaternion
-	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+	recipNorm = 1.0f / sqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
 	q0 *= recipNorm;
 	q1 *= recipNorm;
 	q2 *= recipNorm;


### PR DESCRIPTION
- the original implementation used 1/sqrt() instead of the fast
  invSqrt() function
- invSqrt() causes the estimate to diverge under constant input
- this commit fixes #17
