### PR TITLE
Add ~reverse_tf parameter for the robots which does not have IMU on root link

### DIFF
--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
@@ -81,6 +81,7 @@ class ImuFilter
     double zeta_;	  // gyro drift bias gain
     bool use_mag_;
     bool publish_tf_;
+    bool reverse_tf_;
     std::string fixed_frame_;
     std::string imu_frame_;
     double constant_dt_;

--- a/imu_filter_madgwick/src/imu_filter.cpp
+++ b/imu_filter_madgwick/src/imu_filter.cpp
@@ -39,6 +39,8 @@ ImuFilter::ImuFilter(ros::NodeHandle nh, ros::NodeHandle nh_private):
    use_mag_ = true;
   if (!nh_private_.getParam ("publish_tf", publish_tf_))
    publish_tf_ = true;
+  if (!nh_private_.getParam ("reverse_tf", reverse_tf_))
+   reverse_tf_ = false;
   if (!nh_private_.getParam ("fixed_frame", fixed_frame_))
    fixed_frame_ = "odom";
   if (!nh_private_.getParam ("constant_dt", constant_dt_))
@@ -237,10 +239,20 @@ void ImuFilter::publishTransform(const ImuMsg::ConstPtr& imu_msg_raw)
   tf::Transform transform;
   transform.setOrigin( tf::Vector3( 0.0, 0.0, 0.0 ) );
   transform.setRotation( q );
-  tf_broadcaster_.sendTransform( tf::StampedTransform( transform,
-                   imu_msg_raw->header.stamp,
-                   fixed_frame_,
-                   imu_frame_ ) );
+  if (reverse_tf_)
+  {
+    tf::Transform inv_transform = transform.inverse();
+    tf_broadcaster_.sendTransform( tf::StampedTransform( inv_transform,
+                     imu_msg_raw->header.stamp,
+                     imu_frame_,
+                     fixed_frame_) );
+  }
+  else {
+    tf_broadcaster_.sendTransform( tf::StampedTransform( transform,
+                     imu_msg_raw->header.stamp,
+                     imu_frame_,
+                     fixed_frame_) );
+  }
 
 }
 


### PR DESCRIPTION
Add ~reverse_tf parameter for the robots which do not have IMU on root link.
If this parameter is set True, imu_filter publishes tf `imu_frame --> fixed_frame` instead of 
`fixed_frame --> imu_frame`
