### PR TITLE
complementary_filter: add cmake_modules dependency

### DIFF
--- a/imu_complementary_filter/CMakeLists.txt
+++ b/imu_complementary_filter/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(imu_complementary_filter)
 
 find_package(catkin REQUIRED COMPONENTS
+  cmake_modules
   message_filters
   roscpp
   rospy

--- a/imu_complementary_filter/package.xml
+++ b/imu_complementary_filter/package.xml
@@ -11,6 +11,7 @@
   <author email="robertogl.valenti@gmail.com">Roberto G. Valenti</author> -->
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>


### PR DESCRIPTION
this package provides FindEigen.cmake and without it find_package(Eigen) right
below does not work everywhere.
