### PR TITLE
Fix catkin issues in complementary_filter

### DIFF
--- a/imu_complementary_filter/CMakeLists.txt
+++ b/imu_complementary_filter/CMakeLists.txt
@@ -5,21 +5,19 @@ find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   message_filters
   roscpp
-  rospy
   sensor_msgs
   std_msgs
   tf
 )
+
 find_package(Eigen REQUIRED COMPONENTS)
 
 catkin_package(
   DEPENDS Eigen
   INCLUDE_DIRS include
-  LIBRARIES complementary_filter complementary_filter_node
-  CATKIN_DEPENDS message_filters roscpp rospy sensor_msgs std_msgs tf
-  DEPENDS system_lib
+  LIBRARIES complementary_filter
+  CATKIN_DEPENDS message_filters roscpp sensor_msgs std_msgs tf
 )
-
 
 include_directories(
   include
@@ -29,27 +27,28 @@ include_directories(
 
 ## Declare a cpp library
 add_library(complementary_filter
-    src/complementary_filter.cpp
-    src/complementary_filter_ros.cpp
-    src/complementary_filter_node.cpp
-    include/imu_complementary_filter/complementary_filter.h
-    include/imu_complementary_filter/complementary_filter_ros.h
- )
+  src/complementary_filter.cpp
+  src/complementary_filter_node.cpp
+  src/complementary_filter_ros.cpp
+  include/imu_complementary_filter/complementary_filter.h
+  include/imu_complementary_filter/complementary_filter_ros.h
+)
 
 
 # create complementary_filter_node executable
-add_executable(complementary_filter_node 
-                        src/complementary_filter_node.cpp)
-
+add_executable(complementary_filter_node
+  src/complementary_filter_node.cpp)
 target_link_libraries(complementary_filter_node complementary_filter ${catkin_LIBRARIES} ${Eigen_LIBRARIES})
 
-
+install(TARGETS complementary_filter complementary_filter_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark cpp header files for installation
- install(DIRECTORY include/${PROJECT_NAME}/
-   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-   FILES_MATCHING PATTERN "*.h"
-   PATTERN ".svn" EXCLUDE
- )
-
-
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)

--- a/imu_complementary_filter/package.xml
+++ b/imu_complementary_filter/package.xml
@@ -14,13 +14,11 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>


### PR DESCRIPTION
- don't export complementary_filter_node as a library
- install complementary_filter library + node
- remove dependency on non-existent "system_lib"
- remove dependency on rospy
- fix indentation
