### PR TITLE
complementary: Use MagneticField instead of Vector3

### DIFF
--- a/imu_complementary_filter/include/imu_complementary_filter/complementary_filter_ros.h
+++ b/imu_complementary_filter/include/imu_complementary_filter/complementary_filter_ros.h
@@ -32,7 +32,7 @@
 #ifndef IMU_TOOLS_COMPLEMENTARY_FILTER_ROS_H
 #define IMU_TOOLS_COMPLEMENTARY_FILTER_ROS_H
 
-#include <geometry_msgs/Vector3Stamped.h>
+#include <sensor_msgs/MagneticField.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>
@@ -56,9 +56,9 @@ class ComplementaryFilterROS
 
     // Convenience typedefs
     typedef sensor_msgs::Imu ImuMsg;
-    typedef geometry_msgs::Vector3Stamped MagMsg;
+    typedef sensor_msgs::MagneticField MagMsg;
     typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Imu, 
-        geometry_msgs::Vector3Stamped> MySyncPolicy;
+        MagMsg> MySyncPolicy;
     typedef message_filters::sync_policies::ApproximateTime<ImuMsg, MagMsg> 
         SyncPolicy;
     typedef message_filters::Synchronizer<SyncPolicy> Synchronizer;    

--- a/imu_complementary_filter/src/complementary_filter_ros.cpp
+++ b/imu_complementary_filter/src/complementary_filter_ros.cpp
@@ -155,7 +155,7 @@ void ComplementaryFilterROS::imuMagCallback(const ImuMsg::ConstPtr& imu_msg_raw,
 {
   const geometry_msgs::Vector3& a = imu_msg_raw->linear_acceleration; 
   const geometry_msgs::Vector3& w = imu_msg_raw->angular_velocity;
-  const geometry_msgs::Vector3& m = mag_msg->vector;
+  const geometry_msgs::Vector3& m = mag_msg->magnetic_field;
   const ros::Time& time = imu_msg_raw->header.stamp;
     
   // Initialize.


### PR DESCRIPTION
I would strongly suggest that we use a sensor_msgs/MagneticField instead
of a Vector3Stamped message for the magnetic field. It's the proper
message type, and we should make the switch _now_, before people start
using the package. In `imu_filter_madgwick`, we had to jump through a
lot of hoops to maintain backwards compatibility with Vector3Stamped for
now.

This would also mean that we need to patch the phidgets_imu driver so
that it can optionally publish MagneticField messages, but that should
be done anyway, and it's easy.
