### PR TITLE
Removed main function from shared library

### DIFF
--- a/imu_complementary_filter/CMakeLists.txt
+++ b/imu_complementary_filter/CMakeLists.txt
@@ -28,7 +28,6 @@ include_directories(
 ## Declare a cpp library
 add_library(complementary_filter
   src/complementary_filter.cpp
-  src/complementary_filter_node.cpp
   src/complementary_filter_ros.cpp
   include/imu_complementary_filter/complementary_filter.h
   include/imu_complementary_filter/complementary_filter_ros.h


### PR DESCRIPTION
The main function is currently built into the shared library. This makes it impossible to use the library in other nodes. I removed the imu_complementary_filter_node.cpp from the add_library statement.
