### PR TITLE
Use ENU convention

### DIFF
--- a/imu_filter_madgwick/CMakeLists.txt
+++ b/imu_filter_madgwick/CMakeLists.txt
@@ -52,4 +52,16 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 install(FILES imu_filter_nodelet.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+
+
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(${PROJECT_NAME}-madgwick_test
+    test/madgwick_test.cpp
   )
+  target_link_libraries(${PROJECT_NAME}-madgwick_test
+    imu_filter
+    ${catkin_LIBRARIES}
+  )
+endif()

--- a/imu_filter_madgwick/CMakeLists.txt
+++ b/imu_filter_madgwick/CMakeLists.txt
@@ -24,12 +24,12 @@ include_directories(
 
 
 # create imu_filter library
-add_library (imu_filter src/imu_filter.cpp  src/imu_filter_ros.cpp  include/imu_filter_madgwick/imu_filter.h)
+add_library (imu_filter src/imu_filter.cpp  src/imu_filter_ros.cpp src/stateless_orientation.cpp)
 add_dependencies(imu_filter ${PROJECT_NAME}_gencfg)
 target_link_libraries(imu_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 # create imu_filter_nodelet library
-add_library (imu_filter_nodelet src/imu_filter_nodelet.cpp include/imu_filter_madgwick/imu_filter_nodelet.h)
+add_library (imu_filter_nodelet src/imu_filter_nodelet.cpp)
 add_dependencies(imu_filter_nodelet ${PROJECT_NAME}_gencfg)
 target_link_libraries(imu_filter_nodelet imu_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
@@ -58,6 +58,7 @@ install(FILES imu_filter_nodelet.xml
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(${PROJECT_NAME}-madgwick_test
+    test/stateless_orientation_test.cpp
     test/madgwick_test.cpp
   )
   target_link_libraries(${PROJECT_NAME}-madgwick_test

--- a/imu_filter_madgwick/include/imu_filter_madgwick/earth_frame.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/earth_frame.h
@@ -1,0 +1,8 @@
+#ifndef IMU_FILTER_MADGWICK_EARTH_FRAME_H_
+#define IMU_FILTER_MADGWICK_EARTH_FRAME_H_
+
+namespace EarthFrame {
+  enum EarthFrame { ENU, NED, NWU };
+}
+
+#endif

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
@@ -25,6 +25,9 @@
 #ifndef IMU_FILTER_MADWICK_IMU_FILTER_H
 #define IMU_FILTER_MADWICK_IMU_FILTER_H
 
+#include <imu_filter_madgwick/earth_frame.h>
+#include <iostream>
+
 class ImuFilter
 {
   public:
@@ -34,31 +37,13 @@ class ImuFilter
 
   private:
     // **** paramaters
-    double gain_;     // algorithm gain
-    double zeta_;	  // gyro drift bias gain
+    double gain_;    // algorithm gain
+    double zeta_;    // gyro drift bias gain
+    EarthFrame::EarthFrame earth_frame_;    // NWU, ENU, NED
 
     // **** state variables
     double q0, q1, q2, q3;  // quaternion
     float w_bx_, w_by_, w_bz_; // 
-
-    // **** member functions
-
-    // Fast inverse square-root
-    // See: http://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Reciprocal_of_the_square_root
-    static float invSqrt(float x)
-    {
-      float xhalf = 0.5f * x;
-      union
-      {
-        float x;
-        int i;
-      } u;
-      u.x = x;
-      u.i = 0x5f3759df - (u.i >> 1);
-      /* The next line can be repeated any number of times to increase accuracy */
-      u.x = u.x * (1.5f - xhalf * u.x * u.x);
-      return u.x;
-    }
 
 public:
     void setAlgorithmGain(double gain)
@@ -69,6 +54,11 @@ public:
     void setDriftBiasGain(double zeta)
     {
         zeta_ = zeta;
+    }
+
+    void setEarthFrame(EarthFrame::EarthFrame frame)
+    {
+        earth_frame_ = frame;
     }
 
     void getOrientation(double& q0, double& q1, double& q2, double& q3)

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
@@ -81,6 +81,7 @@ class ImuFilterRos
     boost::shared_ptr<FilterConfigServer> config_server_;
 
     // **** paramaters
+    EarthFrame::EarthFrame earth_frame_;
     bool use_mag_;
     bool use_magnetic_field_msg_;
     bool publish_tf_;
@@ -115,10 +116,6 @@ class ImuFilterRos
                        float roll, float pitch, float yaw);
 
     void reconfigCallback(FilterConfig& config, uint32_t level);
-
-    void computeRPY(float ax, float ay, float az,
-                    float mx, float my, float mz,
-                    float& roll, float& pitch, float& yaw);
 };
 
 #endif // IMU_FILTER_IMU_MADWICK_FILTER_ROS_H

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
@@ -84,6 +84,7 @@ class ImuFilterRos
     EarthFrame::EarthFrame earth_frame_;
     bool use_mag_;
     bool use_magnetic_field_msg_;
+    bool stateless_;
     bool publish_tf_;
     bool reverse_tf_;
     std::string fixed_frame_;

--- a/imu_filter_madgwick/include/imu_filter_madgwick/stateless_orientation.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/stateless_orientation.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2010, CCNY Robotics Lab
+ *  Ivan Dryanovski <ivan.dryanovski@gmail.com>
+ *
+ *  http://robotics.ccny.cuny.edu
+ *
+ *  Based on implementation of Madgwick's IMU and AHRS algorithms.
+ *  http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms
+ *
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef IMU_FILTER_MADWICK_STATELESS_ORIENTATION_H
+#define IMU_FILTER_MADWICK_STATELESS_ORIENTATION_H
+
+#include <geometry_msgs/Vector3.h>
+#include <geometry_msgs/Quaternion.h>
+#include <imu_filter_madgwick/earth_frame.h>
+
+class StatelessOrientation
+{
+public:
+  static bool computeOrientation(
+    EarthFrame::EarthFrame frame,
+    geometry_msgs::Vector3 acceleration,
+    geometry_msgs::Vector3 magneticField,
+    geometry_msgs::Quaternion& orientation);
+
+  static bool computeOrientation(
+    EarthFrame::EarthFrame frame,
+    geometry_msgs::Vector3 acceleration,
+    geometry_msgs::Quaternion& orientation);
+
+};
+
+#endif // IMU_FILTER_MADWICK_STATELESS_ORIENTATION_H

--- a/imu_filter_madgwick/package.xml
+++ b/imu_filter_madgwick/package.xml
@@ -32,6 +32,8 @@
   <run_depend>message_filters</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
 
+  <test_depend>rosunit</test_depend>
+
   <export>
     <nodelet plugin="${prefix}/imu_filter_nodelet.xml" />
   </export>

--- a/imu_filter_madgwick/src/imu_filter.cpp
+++ b/imu_filter_madgwick/src/imu_filter.cpp
@@ -25,10 +25,146 @@
 #include <cmath>
 #include "imu_filter_madgwick/imu_filter.h"
 
-ImuFilter::ImuFilter():
-  q0(1.0), q1(0.0), q2(0.0), q3(0.0),
-  w_bx_(0.0), w_by_(0.0), w_bz_(0.0),
-  zeta_(0.0), gain_(0.0)
+// Fast inverse square-root
+// See: http://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Reciprocal_of_the_square_root
+static float invSqrt(float x)
+{
+  float xhalf = 0.5f * x;
+  union
+  {
+    float x;
+    int i;
+  } u;
+  u.x = x;
+  u.i = 0x5f3759df - (u.i >> 1);
+  /* The next line can be repeated any number of times to increase accuracy */
+  u.x = u.x * (1.5f - xhalf * u.x * u.x);
+  return u.x;
+}
+
+template<typename T>
+static inline void normalizeVector(T& vx, T& vy, T& vz)
+{
+  T recipNorm = invSqrt (vx * vx + vy * vy + vz * vz);
+  vx *= recipNorm;
+  vy *= recipNorm;
+  vz *= recipNorm;
+}
+
+template<typename T>
+static inline void normalizeQuaternion(T& q0, T& q1, T& q2, T& q3)
+{
+  T recipNorm = invSqrt (q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+  q0 *= recipNorm;
+  q1 *= recipNorm;
+  q2 *= recipNorm;
+  q3 *= recipNorm;
+}
+
+static inline void rotateAndScaleVector(
+    float q0, float q1, float q2, float q3,
+    float _2dx, float _2dy, float _2dz,
+    float& rx, float& ry, float& rz) {
+
+  // result is half as long as input
+  rx = _2dx * (0.5f - q2 * q2 - q3 * q3)
+     + _2dy * (q0 * q3 + q1 * q2)
+     + _2dz * (q1 * q3 - q0 * q2);
+  ry = _2dx * (q1 * q2 - q0 * q3)
+     + _2dy * (0.5f - q1 * q1 - q3 * q3)
+     + _2dz * (q0 * q1 + q2 * q3);
+  rz = _2dx * (q0 * q2 + q1 * q3)
+     + _2dy * (q2 * q3 - q0 * q1)
+     + _2dz * (0.5f - q1 * q1 - q2 * q2);
+}
+
+
+static inline void compensateGyroDrift(
+    float q0, float q1, float q2, float q3,
+    float s0, float s1, float s2, float s3,
+    float dt, float zeta,
+    float& w_bx, float& w_by, float& w_bz,
+    float& gx, float& gy, float& gz)
+{
+  // w_err = 2 q x s
+  float w_err_x = 2.0f * q0 * s1 - 2.0f * q1 * s0 - 2.0f * q2 * s3 + 2.0f * q3 * s2;
+  float w_err_y = 2.0f * q0 * s2 + 2.0f * q1 * s3 - 2.0f * q2 * s0 - 2.0f * q3 * s1;
+  float w_err_z = 2.0f * q0 * s3 - 2.0f * q1 * s2 + 2.0f * q2 * s1 - 2.0f * q3 * s0;
+
+  w_bx += w_err_x * dt * zeta;
+  w_by += w_err_y * dt * zeta;
+  w_bz += w_err_z * dt * zeta;
+
+  gx -= w_bx;
+  gy -= w_by;
+  gz -= w_bz;
+}
+
+static inline void orientationChangeFromGyro(
+    float q0, float q1, float q2, float q3,
+    float gx, float gy, float gz,
+    float& qDot1, float& qDot2, float& qDot3, float& qDot4)
+{
+  // Rate of change of quaternion from gyroscope
+  // See EQ 12
+  qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
+  qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
+  qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
+  qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
+}
+
+static inline void addGradientDescentStep(
+    float q0, float q1, float q2, float q3,
+    float _2dx, float _2dy, float _2dz,
+    float mx, float my, float mz,
+    float& s0, float& s1, float& s2, float& s3)
+{
+  float f0, f1, f2;
+
+  // Gradient decent algorithm corrective step
+  // EQ 15, 21
+  rotateAndScaleVector(q0,q1,q2,q3, _2dx, _2dy, _2dz, f0, f1, f2);
+
+  f0 -= mx;
+  f1 -= my;
+  f2 -= mz;
+
+
+  // EQ 22, 34
+  // Jt * f
+  s0 += (_2dy * q3 - _2dz * q2) * f0
+      + (-_2dx * q3 + _2dz * q1) * f1
+      + (_2dx * q2 - _2dy * q1) * f2;
+  s1 += (_2dy * q2 + _2dz * q3) * f0
+      + (_2dx * q2 - 2.0f * _2dy * q1 + _2dz * q0) * f1
+      + (_2dx * q3 - _2dy * q0 - 2.0f * _2dz * q1) * f2;
+  s2 += (-2.0f * _2dx * q2 + _2dy * q1 - _2dz * q0) * f0
+      + (_2dx * q1 + _2dz * q3) * f1
+      + (_2dx * q0 + _2dy * q3 - 2.0f * _2dz * q2) * f2;
+  s3 += (-2.0f * _2dx * q3 + _2dy * q0 + _2dz * q1) * f0
+      + (-_2dx * q0 - 2.0f * _2dy * q3 + _2dz * q2) * f1
+      + (_2dx * q1 + _2dy * q2) * f2;
+}
+
+static inline void compensateMagneticDistortion(
+    float q0, float q1, float q2, float q3,
+    float mx, float my, float mz,
+    float& _2bxy, float& _2bz)
+{
+  float hx, hy, hz;
+  // Reference direction of Earth's magnetic field (See EQ 46)
+  rotateAndScaleVector(q0, -q1, -q2, -q3, mx, my, mz, hx, hy, hz);
+
+  _2bxy = 4.0f * sqrt (hx * hx + hy * hy);
+  _2bz = 4.0f * hz;
+
+}
+
+
+ImuFilter::ImuFilter() :
+    q0(1.0), q1(0.0), q2(0.0), q3(0.0),
+    w_bx_(0.0), w_by_(0.0), w_bz_(0.0),
+    zeta_ (0.0), gain_ (0.0), earth_frame_(EarthFrame::ENU)
 {
 }
 
@@ -37,195 +173,139 @@ ImuFilter::~ImuFilter()
 }
 
 void ImuFilter::madgwickAHRSupdate(
-  float gx, float gy, float gz, 
-  float ax, float ay, float az, 
-  float mx, float my, float mz, 
-  float dt)
+    float gx, float gy, float gz,
+    float ax, float ay, float az,
+    float mx, float my, float mz,
+    float dt)
 {
-	float recipNorm;
-	float s0, s1, s2, s3;
-	float qDot1, qDot2, qDot3, qDot4;
-	float hx, hy;
-	float _2q0mx, _2q0my, _2q0mz, _2q1mx, _2bx, _2bz, _4bx, _4bz, _2q0, _2q1, _2q2, _2q3, _2q0q2, _2q2q3, q0q0, q0q1, q0q2, q0q3, q1q1, q1q2, q1q3, q2q2, q2q3, q3q3;
-	float _w_err_x, _w_err_y, _w_err_z;
+  float s0, s1, s2, s3;
+  float qDot1, qDot2, qDot3, qDot4;
+  float _2bz, _2bxy;
 
-	// Use IMU algorithm if magnetometer measurement invalid (avoids NaN in magnetometer normalisation)
-  if(!std::isfinite(mx) || !std::isfinite(my) || !std::isfinite(mz))
+  // Use IMU algorithm if magnetometer measurement invalid (avoids NaN in magnetometer normalisation)
+  if (!std::isfinite(mx) || !std::isfinite(my) || !std::isfinite(mz))
   {
-		madgwickAHRSupdateIMU(gx, gy, gz, ax, ay, az, dt);
-		return;
-	}
+    madgwickAHRSupdateIMU(gx, gy, gz, ax, ay, az, dt);
+    return;
+  }
 
-	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
-	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) 
+  // Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+  if (!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f)))
   {
-		// Normalise accelerometer measurement
-		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
-		ax *= recipNorm;
-		ay *= recipNorm;
-		az *= recipNorm;   
+    // Normalise accelerometer measurement
+    normalizeVector(ax, ay, az);
 
-		// Normalise magnetometer measurement
-		recipNorm = invSqrt(mx * mx + my * my + mz * mz);
-		mx *= recipNorm;
-		my *= recipNorm;
-		mz *= recipNorm;
+    // Normalise magnetometer measurement
+    normalizeVector(mx, my, mz);
 
-		// Auxiliary variables to avoid repeated arithmetic
-		_2q0mx = 2.0f * q0 * mx;
-		_2q0my = 2.0f * q0 * my;
-		_2q0mz = 2.0f * q0 * mz;
-		_2q1mx = 2.0f * q1 * mx;
-		_2q0 = 2.0f * q0;
-		_2q1 = 2.0f * q1;
-		_2q2 = 2.0f * q2;
-		_2q3 = 2.0f * q3;
-		_2q0q2 = 2.0f * q0 * q2;
-		_2q2q3 = 2.0f * q2 * q3;
-		q0q0 = q0 * q0;
-		q0q1 = q0 * q1;
-		q0q2 = q0 * q2;
-		q0q3 = q0 * q3;
-		q1q1 = q1 * q1;
-		q1q2 = q1 * q2;
-		q1q3 = q1 * q3;
-		q2q2 = q2 * q2;
-		q2q3 = q2 * q3;
-		q3q3 = q3 * q3;
+    // Compensate for magnetic distortion
+    compensateMagneticDistortion(q0, q1, q2, q3, mx, my, mz, _2bxy, _2bz);
 
-		// Reference direction of Earth's magnetic field
-		hx = mx * q0q0 - _2q0my * q3 + _2q0mz * q2 + mx * q1q1 + _2q1 * my * q2 + _2q1 * mz * q3 - mx * q2q2 - mx * q3q3;
-		hy = _2q0mx * q3 + my * q0q0 - _2q0mz * q1 + _2q1mx * q2 - my * q1q1 + my * q2q2 + _2q2 * mz * q3 - my * q3q3;
-		_2bx = sqrt(hx * hx + hy * hy);
-		_2bz = -_2q0mx * q2 + _2q0my * q1 + mz * q0q0 + _2q1mx * q3 - mz * q1q1 + _2q2 * my * q3 - mz * q2q2 + mz * q3q3;
-		_4bx = 2.0f * _2bx;
-		_4bz = 2.0f * _2bz;
+    // Gradient decent algorithm corrective step
+    s0 = 0.0;  s1 = 0.0;  s2 = 0.0;  s3 = 0.0;
+    switch (earth_frame_) {
+      case EarthFrame::NED:
+        // Gravity: [0, 0, -1]
+        addGradientDescentStep(q0, q1, q2, q3, 0.0, 0.0, -2.0, ax, ay, az, s0, s1, s2, s3);
 
-		// Gradient decent algorithm corrective step
-		s0 = -_2q2 * (2.0f * q1q3 - _2q0q2 - ax) + _2q1 * (2.0f * q0q1 + _2q2q3 - ay) - _2bz * q2 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q3 + _2bz * q1) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q2 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-		s1 = _2q3 * (2.0f * q1q3 - _2q0q2 - ax) + _2q0 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q1 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + _2bz * q3 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q2 + _2bz * q0) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q3 - _4bz * q1) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-		s2 = -_2q0 * (2.0f * q1q3 - _2q0q2 - ax) + _2q3 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q2 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + (-_4bx * q2 - _2bz * q0) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q1 + _2bz * q3) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q0 - _4bz * q2) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-		s3 = _2q1 * (2.0f * q1q3 - _2q0q2 - ax) + _2q2 * (2.0f * q0q1 + _2q2q3 - ay) + (-_4bx * q3 + _2bz * q1) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q0 + _2bz * q2) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q1 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
-		s0 *= recipNorm;
-		s1 *= recipNorm;
-		s2 *= recipNorm;
-		s3 *= recipNorm;
+        // Earth magnetic field: = [bxy, 0, bz]
+        addGradientDescentStep(q0,q1,q2,q3, _2bxy, 0.0, _2bz, mx, my, mz, s0, s1, s2, s3);
+        break;
+      case EarthFrame::NWU:
+        // Gravity: [0, 0, 1]
+        addGradientDescentStep(q0, q1, q2, q3, 0.0, 0.0, 2.0, ax, ay, az, s0, s1, s2, s3);
 
-		// compute gyro drift bias
-		_w_err_x = _2q0 * s1 - _2q1 * s0 - _2q2 * s3 + _2q3 * s2;
-		_w_err_y = _2q0 * s2 + _2q1 * s3 - _2q2 * s0 - _2q3 * s1;
-		_w_err_z = _2q0 * s3 - _2q1 * s2 + _2q2 * s1 - _2q3 * s0;
-		
-		w_bx_ += _w_err_x * dt * zeta_;
-		w_by_ += _w_err_y * dt * zeta_;
-		w_bz_ += _w_err_z * dt * zeta_;
-		
-		gx -= w_bx_;
-		gy -= w_by_;
-		gz -= w_bz_;
-		
-		// Rate of change of quaternion from gyroscope
-		qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
-		qDot2 = 0.5f * ( q0 * gx + q2 * gz - q3 * gy);
-		qDot3 = 0.5f * ( q0 * gy - q1 * gz + q3 * gx);
-		qDot4 = 0.5f * ( q0 * gz + q1 * gy - q2 * gx);
+        // Earth magnetic field: = [bxy, 0, bz]
+        addGradientDescentStep(q0,q1,q2,q3, _2bxy, 0.0, _2bz, mx, my, mz, s0, s1, s2, s3);
+        break;
+      default:
+      case EarthFrame::ENU:
+        // Gravity: [0, 0, 1]
+        addGradientDescentStep(q0, q1, q2, q3, 0.0, 0.0, 2.0, ax, ay, az, s0, s1, s2, s3);
 
-		// Apply feedback step
-		qDot1 -= gain_ * s0;
-		qDot2 -= gain_ * s1;
-		qDot3 -= gain_ * s2;
-		qDot4 -= gain_ * s3;
-	} else{
-		// Rate of change of quaternion from gyroscope
-		qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
-		qDot2 = 0.5f * ( q0 * gx + q2 * gz - q3 * gy);
-		qDot3 = 0.5f * ( q0 * gy - q1 * gz + q3 * gx);
-		qDot4 = 0.5f * ( q0 * gz + q1 * gy - q2 * gx);
-	}
+        // Earth magnetic field: = [0, bxy, bz]
+        addGradientDescentStep(q0, q1, q2, q3, 0.0, _2bxy, _2bz, mx, my, mz, s0, s1, s2, s3);
+        break;
+    }
+    normalizeQuaternion(s0, s1, s2, s3);
 
-	// Integrate rate of change of quaternion to yield quaternion
-	q0 += qDot1 * dt;
-	q1 += qDot2 * dt;
-	q2 += qDot3 * dt;
-	q3 += qDot4 * dt;
+    // compute gyro drift bias
+    compensateGyroDrift(q0, q1, q2, q3, s0, s1, s2, s3, dt, zeta_, w_bx_, w_by_, w_bz_, gx, gy, gz);
 
-	// Normalise quaternion
-	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
-	q0 *= recipNorm;
-	q1 *= recipNorm;
-	q2 *= recipNorm;
-	q3 *= recipNorm;
+    orientationChangeFromGyro(q0, q1, q2, q3, gx, gy, gz, qDot1, qDot2, qDot3, qDot4);
+
+    // Apply feedback step
+    qDot1 -= gain_ * s0;
+    qDot2 -= gain_ * s1;
+    qDot3 -= gain_ * s2;
+    qDot4 -= gain_ * s3;
+  }
+  else
+  {
+    orientationChangeFromGyro(q0, q1, q2, q3, gx, gy, gz, qDot1, qDot2, qDot3, qDot4);
+  }
+
+  // Integrate rate of change of quaternion to yield quaternion
+  q0 += qDot1 * dt;
+  q1 += qDot2 * dt;
+  q2 += qDot3 * dt;
+  q3 += qDot4 * dt;
+
+  // Normalise quaternion
+  normalizeQuaternion(q0, q1, q2, q3);
 }
 
 void ImuFilter::madgwickAHRSupdateIMU(
-  float gx, float gy, float gz, 
-  float ax, float ay, float az,
-  float dt) 
+    float gx, float gy, float gz,
+    float ax, float ay, float az,
+    float dt)
 {
-	float recipNorm;
-	float s0, s1, s2, s3;
-	float qDot1, qDot2, qDot3, qDot4;
-	float _2q0, _2q1, _2q2, _2q3, _4q0, _4q1, _4q2 ,_8q1, _8q2, q0q0, q1q1, q2q2, q3q3;
+  float recipNorm;
+  float s0, s1, s2, s3;
+  float qDot1, qDot2, qDot3, qDot4;
 
-	// Rate of change of quaternion from gyroscope
-	qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
-	qDot2 = 0.5f * ( q0 * gx + q2 * gz - q3 * gy);
-	qDot3 = 0.5f * ( q0 * gy - q1 * gz + q3 * gx);
-	qDot4 = 0.5f * ( q0 * gz + q1 * gy - q2 * gx);
+  // Rate of change of quaternion from gyroscope
+  orientationChangeFromGyro (q0, q1, q2, q3, gx, gy, gz, qDot1, qDot2, qDot3, qDot4);
 
-	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
-	if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f))) 
+  // Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+  if (!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f)))
   {
-		// Normalise accelerometer measurement
-		recipNorm = invSqrt(ax * ax + ay * ay + az * az);
-		ax *= recipNorm;
-		ay *= recipNorm;
-		az *= recipNorm;   
+    // Normalise accelerometer measurement
+    normalizeVector(ax, ay, az);
 
-		// Auxiliary variables to avoid repeated arithmetic
-		_2q0 = 2.0f * q0;
-		_2q1 = 2.0f * q1;
-		_2q2 = 2.0f * q2;
-		_2q3 = 2.0f * q3;
-		_4q0 = 4.0f * q0;
-		_4q1 = 4.0f * q1;
-		_4q2 = 4.0f * q2;
-		_8q1 = 8.0f * q1;
-		_8q2 = 8.0f * q2;
-		q0q0 = q0 * q0;
-		q1q1 = q1 * q1;
-		q2q2 = q2 * q2;
-		q3q3 = q3 * q3;
+    // Gradient decent algorithm corrective step
+    s0 = 0.0;  s1 = 0.0;  s2 = 0.0;  s3 = 0.0;
+    switch (earth_frame_) {
+      case EarthFrame::NED:
+        // Gravity: [0, 0, -1]
+        addGradientDescentStep(q0, q1, q2, q3, 0.0, 0.0, -2.0, ax, ay, az, s0, s1, s2, s3);
+        break;
+      case EarthFrame::NWU:
+        // Gravity: [0, 0, 1]
+        addGradientDescentStep(q0, q1, q2, q3, 0.0, 0.0, 2.0, ax, ay, az, s0, s1, s2, s3);
+        break;
+      default:
+      case EarthFrame::ENU:
+        // Gravity: [0, 0, 1]
+        addGradientDescentStep(q0, q1, q2, q3, 0.0, 0.0, 2.0, ax, ay, az, s0, s1, s2, s3);
+        break;
+    }
 
-		// Gradient decent algorithm corrective step
-		s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
-		s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1 - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
-		s2 = 4.0f * q0q0 * q2 + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
-		s3 = 4.0f * q1q1 * q3 - _2q1 * ax + 4.0f * q2q2 * q3 - _2q2 * ay;
-		recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
-		s0 *= recipNorm;
-		s1 *= recipNorm;
-		s2 *= recipNorm;
-		s3 *= recipNorm;
+    normalizeQuaternion(s0, s1, s2, s3);
 
-		// Apply feedback step
-		qDot1 -= gain_ * s0;
-		qDot2 -= gain_ * s1;
-		qDot3 -= gain_ * s2;
-		qDot4 -= gain_ * s3;
-	}
+    // Apply feedback step
+    qDot1 -= gain_ * s0;
+    qDot2 -= gain_ * s1;
+    qDot3 -= gain_ * s2;
+    qDot4 -= gain_ * s3;
+  }
 
-	// Integrate rate of change of quaternion to yield quaternion
-	q0 += qDot1 * dt;
-	q1 += qDot2 * dt;
-	q2 += qDot3 * dt;
-	q3 += qDot4 * dt;
+  // Integrate rate of change of quaternion to yield quaternion
+  q0 += qDot1 * dt;
+  q1 += qDot2 * dt;
+  q2 += qDot3 * dt;
+  q3 += qDot4 * dt;
 
-	// Normalise quaternion
-	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
-	q0 *= recipNorm;
-	q1 *= recipNorm;
-	q2 *= recipNorm;
-	q3 *= recipNorm;
+  // Normalise quaternion
+  normalizeQuaternion (q0, q1, q2, q3);
 }

--- a/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "imu_filter_madgwick/imu_filter_ros.h"
+#include "imu_filter_madgwick/stateless_orientation.h"
 #include "geometry_msgs/TransformStamped.h"
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Matrix3x3.h>
@@ -35,7 +36,6 @@ ImuFilterRos::ImuFilterRos(ros::NodeHandle nh, ros::NodeHandle nh_private):
   ROS_INFO ("Starting ImuFilter");
 
   // **** get paramters
-
   if (!nh_private_.getParam ("use_mag", use_mag_))
    use_mag_ = true;
   if (!nh_private_.getParam ("publish_tf", publish_tf_))
@@ -59,6 +59,31 @@ ImuFilterRos::ImuFilterRos(ros::NodeHandle nh, ros::NodeHandle nh_private):
       }
       use_magnetic_field_msg_ = false;
   }
+
+  bool use_ned, use_nwu;
+  // Default should become false for next release
+  if (!nh_private_.getParam ("use_ned", use_ned)) {
+      use_ned = false;
+  }
+  // Default should become false for next release
+  if (!nh_private_.getParam ("use_nwu", use_nwu)) {
+      use_nwu = true;
+      ROS_WARN("Deprecation Warning: The parameter use_nwu was not set, default is 'true'.");
+      ROS_WARN("Starting with ROS Lunar, use_nwu will default to 'false'!");
+  }
+  if (use_ned && use_nwu) {
+      ROS_WARN("Cannot use NED and NWU. Using NED.");
+      use_nwu = false;
+  }
+
+  if (use_ned) {
+    earth_frame_ = EarthFrame::NED;
+  } else if (use_nwu){
+    earth_frame_ = EarthFrame::NWU;
+  } else {
+    earth_frame_ = EarthFrame::ENU;
+  }
+  filter_.setEarthFrame(earth_frame_);
 
   // check for illegal constant_dt values
   if (constant_dt_ < 0.0)
@@ -147,16 +172,9 @@ void ImuFilterRos::imuCallback(const ImuMsg::ConstPtr& imu_msg_raw)
 
   if (!initialized_)
   {
-    // initialize roll/pitch orientation from acc. vector
-    double sign = copysignf(1.0, lin_acc.z);
-    double roll = atan2(lin_acc.y, sign * sqrt(lin_acc.x*lin_acc.x + lin_acc.z*lin_acc.z));
-    double pitch = -atan2(lin_acc.x, sqrt(lin_acc.y*lin_acc.y + lin_acc.z*lin_acc.z));
-    double yaw = 0.0;
-
-    tf2::Quaternion init_q;
-    init_q.setRPY(roll, pitch, yaw);
-
-    filter_.setOrientation(init_q.getW(), init_q.getX(), init_q.getY(), init_q.getZ());
+    geometry_msgs::Quaternion init_q;
+    StatelessOrientation::computeOrientation(earth_frame_, lin_acc, init_q);
+    filter_.setOrientation(init_q.w, init_q.x, init_q.y, init_q.z);
 
     // initialize time
     last_time_ = time;
@@ -196,13 +214,14 @@ void ImuFilterRos::imuMagCallback(
   imu_frame_ = imu_msg_raw->header.frame_id;
 
   /*** Compensate for hard iron ***/
-  double mx = mag_fld.x - mag_bias_.x;
-  double my = mag_fld.y - mag_bias_.y;
-  double mz = mag_fld.z - mag_bias_.z;
+  geometry_msgs::Vector3 mag_compensated;
+  mag_compensated.x = mag_fld.x - mag_bias_.x;
+  mag_compensated.y = mag_fld.y - mag_bias_.y;
+  mag_compensated.z = mag_fld.z - mag_bias_.z;
 
-  float roll = 0.0;
-  float pitch = 0.0;
-  float yaw = 0.0;
+  double roll = 0.0;
+  double pitch = 0.0;
+  double yaw = 0.0;
 
   if (!initialized_)
   {
@@ -212,15 +231,9 @@ void ImuFilterRos::imuMagCallback(
       return;
     }
 
-    computeRPY(
-      lin_acc.x, lin_acc.y, lin_acc.z,
-      mx, my, mz,
-      roll, pitch, yaw);
-
-    tf2::Quaternion init_q;
-    init_q.setRPY(roll, pitch, yaw);
-
-    filter_.setOrientation(init_q.getW(), init_q.getX(), init_q.getY(), init_q.getZ());
+    geometry_msgs::Quaternion init_q;
+    StatelessOrientation::computeOrientation(earth_frame_, lin_acc, mag_compensated, init_q);
+    filter_.setOrientation(init_q.w, init_q.x, init_q.y, init_q.z);
 
     last_time_ = time;
     initialized_ = true;
@@ -238,21 +251,21 @@ void ImuFilterRos::imuMagCallback(
   filter_.madgwickAHRSupdate(
     ang_vel.x, ang_vel.y, ang_vel.z,
     lin_acc.x, lin_acc.y, lin_acc.z,
-    mx, my, mz,
+    mag_compensated.x, mag_compensated.y, mag_compensated.z,
     dt);
 
   publishFilteredMsg(imu_msg_raw);
   if (publish_tf_)
     publishTransform(imu_msg_raw);
 
-  if(publish_debug_topics_ && std::isfinite(mx) && std::isfinite(my) && std::isfinite(mz))
+  if(publish_debug_topics_)
   {
-    computeRPY(
-      lin_acc.x, lin_acc.y, lin_acc.z,
-      mx, my, mz,
-      roll, pitch, yaw);
-
-    publishRawMsg(time, roll, pitch, yaw);
+    geometry_msgs::Quaternion orientation;
+    if (StatelessOrientation::computeOrientation(earth_frame_, lin_acc, mag_compensated, orientation))
+    {
+      tf2::Matrix3x3(tf2::Quaternion(orientation.x, orientation.y, orientation.z, orientation.w)).getRPY(roll, pitch, yaw, 0);
+      publishRawMsg(time, roll, pitch, yaw);
+    }
   }
 }
 
@@ -331,26 +344,6 @@ void ImuFilterRos::publishRawMsg(const ros::Time& t,
   rpy_raw_debug_publisher_.publish(rpy);
 }
 
-void ImuFilterRos::computeRPY(
-  float ax, float ay, float az,
-  float mx, float my, float mz,
-  float& roll, float& pitch, float& yaw)
-{
-  // initialize roll/pitch orientation from acc. vector.
-  double sign = copysignf(1.0, az);
-  roll = atan2(ay, sign * sqrt(ax*ax + az*az));
-  pitch = -atan2(ax, sqrt(ay*ay + az*az));
-  double cos_roll = cos(roll);
-  double sin_roll = sin(roll);
-  double cos_pitch = cos(pitch);
-  double sin_pitch = sin(pitch);
-
-  // initialize yaw orientation from magnetometer data.
-  /***  From: http://cache.freescale.com/files/sensors/doc/app_note/AN4248.pdf (equation 22). ***/
-  double head_x = mx * cos_pitch + my * sin_pitch * sin_roll + mz * sin_pitch * cos_roll;
-  double head_y = my * cos_roll - mz * sin_roll;
-  yaw = atan2(-head_y, head_x);
-}
 
 void ImuFilterRos::reconfigCallback(FilterConfig& config, uint32_t level)
 {

--- a/imu_filter_madgwick/src/stateless_orientation.cpp
+++ b/imu_filter_madgwick/src/stateless_orientation.cpp
@@ -1,0 +1,172 @@
+/*
+ *  Copyright (C) 2010, CCNY Robotics Lab
+ *  Ivan Dryanovski <ivan.dryanovski@gmail.com>
+ *
+ *  http://robotics.ccny.cuny.edu
+ *
+ *  Based on implementation of Madgwick's IMU and AHRS algorithms.
+ *  http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms
+ *
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "imu_filter_madgwick/stateless_orientation.h"
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/convert.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+template<typename T>
+static inline void crossProduct(
+      T ax, T ay, T az,
+      T bx, T by, T bz,
+      T& rx, T& ry, T& rz) {
+  rx = ay*bz - az*by;
+  ry = az*bx - ax*bz;
+  rz = ax*by - ay*bx;
+}
+
+
+template<typename T>
+static inline T normalizeVector(T& vx, T& vy, T& vz) {
+  T norm = sqrt(vx*vx + vy*vy + vz*vz);
+  T inv = 1.0 / norm;
+  vx *= inv;
+  vy *= inv;
+  vz *= inv;
+  return norm;
+
+}
+
+
+bool StatelessOrientation::computeOrientation(
+  EarthFrame::EarthFrame frame,
+  geometry_msgs::Vector3 A,
+  geometry_msgs::Vector3 E,
+  geometry_msgs::Quaternion& orientation) {
+
+  float Hx, Hy, Hz;
+  float Mx, My, Mz;
+  float normH, invH, invA;
+
+  // A: pointing up
+  float Ax = A.x, Ay = A.y, Az = A.z;
+
+  // E: pointing down/north
+  float Ex = E.x, Ey = E.y, Ez = E.z;
+
+  // H: vector horizontal, pointing east
+  // H = E x A
+  crossProduct(Ex, Ey, Ez, Ax, Ay, Az, Hx, Hy, Hz);
+
+  // normalize H
+  normH = normalizeVector(Hx, Hy, Hz);
+  if (normH < 1E-7) {
+    // device is close to free fall (or in space?), or close to
+    // magnetic north pole.
+    // mag in T => Threshold 1E-7, typical values are  > 1E-5.
+    return false;
+  }
+
+  // normalize A
+  normalizeVector(Ax, Ay, Az);
+
+  // M: vector horizontal, pointing north
+  // M = A x H
+  crossProduct(Ax, Ay, Az, Hx, Hy, Hz, Mx, My, Mz);
+
+  // Create matrix for basis transformation
+  tf2::Matrix3x3 R;
+  switch (frame) {
+    case EarthFrame::NED:
+      // vector space world W:
+      // Basis: bwx (1,0,0) north, bwy (0,1,0) east, bwz (0,0,1) down
+      // vector space local L:
+      // Basis: M ,H, -A
+      // W(1,0,0) => L(M)
+      // W(0,1,0) => L(H)
+      // W(0,0,1) => L(-A)
+
+      // R: Transform Matrix local => world equals basis of L, because basis of W is I
+      R[0][0] = Mx;     R[0][1] = Hx;     R[0][2] = -Ax;
+      R[1][0] = My;     R[1][1] = Hy;     R[1][2] = -Ay;
+      R[2][0] = Mz;     R[2][1] = Hz;     R[2][2] = -Az;
+      break;
+
+    case EarthFrame::NWU:
+      // vector space world W:
+      // Basis: bwx (1,0,0) north, bwy (0,1,0) west, bwz (0,0,1) up
+      // vector space local L:
+      // Basis: M ,H, -A
+      // W(1,0,0) => L(M)
+      // W(0,1,0) => L(-H)
+      // W(0,0,1) => L(A)
+
+      // R: Transform Matrix local => world equals basis of L, because basis of W is I
+      R[0][0] = Mx;     R[0][1] = -Hx;     R[0][2] = Ax;
+      R[1][0] = My;     R[1][1] = -Hy;     R[1][2] = Ay;
+      R[2][0] = Mz;     R[2][1] = -Hz;     R[2][2] = Az;
+      break;
+
+    default:
+    case EarthFrame::ENU:
+      // vector space world W:
+      // Basis: bwx (1,0,0) east, bwy (0,1,0) north, bwz (0,0,1) up
+      // vector space local L:
+      // Basis: H, M , A
+      // W(1,0,0) => L(H)
+      // W(0,1,0) => L(M)
+      // W(0,0,1) => L(A)
+
+      // R: Transform Matrix local => world equals basis of L, because basis of W is I
+      R[0][0] = Hx;     R[0][1] = Mx;     R[0][2] = Ax;
+      R[1][0] = Hy;     R[1][1] = My;     R[1][2] = Ay;
+      R[2][0] = Hz;     R[2][1] = Mz;     R[2][2] = Az;
+      break;
+  }
+
+  // Matrix.getRotation assumes vector rotation, but we're using
+  // coordinate systems. Thus negate rotation angle (inverse).
+  tf2::Quaternion q;
+  R.getRotation(q);
+  tf2::convert(q.inverse(), orientation);
+  return true;
+}
+
+
+bool StatelessOrientation::computeOrientation(
+  EarthFrame::EarthFrame frame,
+  geometry_msgs::Vector3 A,
+  geometry_msgs::Quaternion& orientation) {
+
+  // This implementation could be optimized regarding speed.
+
+  // magnetic Field E must not be parallel to A,
+  // choose an arbitrary orthogonal vector
+  geometry_msgs::Vector3 E;
+  if (fabs(A.x) > 0.1 || fabs(A.y) > 0.1) {
+      E.x = A.y;
+      E.y = A.x;
+      E.z = 0.0;
+  } else if (fabs(A.z) > 0.1) {
+      E.x = 0.0;
+      E.y = A.z;
+      E.z = A.y;
+  } else {
+      // free fall
+      return false;
+  }
+
+  return computeOrientation(frame, A, E, orientation);
+}

--- a/imu_filter_madgwick/test/madgwick_test.cpp
+++ b/imu_filter_madgwick/test/madgwick_test.cpp
@@ -4,6 +4,8 @@
 
 #define FILTER_ITERATIONS 10000
 
+
+template <EarthFrame::EarthFrame FRAME>
 void filterStationary(
     float Ax, float Ay, float Az,
     float Mx, float My, float Mz,
@@ -17,6 +19,7 @@ void filterStationary(
 
   // initialize with some orientation
   filter.setOrientation(q0,q1,q2,q3);
+  filter.setEarthFrame(FRAME);
 
   for (int i = 0; i < FILTER_ITERATIONS; i++) {
       filter.madgwickAHRSupdate(Gx, Gy, Gz, Ax, Ay, Az, Mx, My, Mz, dt);
@@ -25,18 +28,41 @@ void filterStationary(
   filter.getOrientation(q0,q1,q2,q3);
 }
 
-#define TEST_STATIONARY_NWU(in_am, exp_result)       \
+
+#define TEST_STATIONARY_ENU(in_am, exp_result)       \
+  TEST(MadgwickTest, Stationary_ENU_ ## in_am){      \
+    double q0 = .5, q1 = .5, q2 = .5, q3 = .5;       \
+    filterStationary<EarthFrame::ENU>(in_am, q0, q1, q2, q3);  \
+    ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+
+#define TEST_STATIONARY_NED(in_am, exp_result)       \
   TEST(MadgwickTest, Stationary_NED_ ## in_am){      \
     double q0 = .5, q1 = .5, q2 = .5, q3 = .5;       \
-    filterStationary(in_am, q0, q1, q2, q3);  \
+    filterStationary<EarthFrame::NED>(in_am, q0, q1, q2, q3);  \
+    ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+
+#define TEST_STATIONARY_NWU(in_am, exp_result)       \
+  TEST(MadgwickTest, Stationary_NWU_ ## in_am){      \
+    double q0 = .5, q1 = .5, q2 = .5, q3 = .5;       \
+    filterStationary<EarthFrame::NWU>(in_am, q0, q1, q2, q3);  \
     ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
 
 TEST_STATIONARY_NWU(AM_NORTH_EAST_DOWN, QUAT_X_180)
 TEST_STATIONARY_NWU(AM_NORTH_WEST_UP, QUAT_IDENTITY)
-
-// Real sensor data tests
 TEST_STATIONARY_NWU(AM_WEST_NORTH_DOWN_RSD, QUAT_WEST_NORTH_DOWN_RSD_NWU)
 TEST_STATIONARY_NWU(AM_NE_NW_UP_RSD, QUAT_NE_NW_UP_RSD_NWU)
+
+TEST_STATIONARY_ENU(AM_EAST_NORTH_UP, QUAT_IDENTITY)
+TEST_STATIONARY_ENU(AM_SOUTH_UP_WEST, QUAT_XMYMZ_120)
+TEST_STATIONARY_ENU(AM_SOUTH_EAST_UP, QUAT_MZ_90)
+TEST_STATIONARY_ENU(AM_WEST_NORTH_DOWN_RSD, QUAT_WEST_NORTH_DOWN_RSD_ENU)
+TEST_STATIONARY_ENU(AM_NE_NW_UP_RSD, QUAT_NE_NW_UP_RSD_ENU)
+
+TEST_STATIONARY_NED(AM_NORTH_EAST_DOWN, QUAT_IDENTITY)
+TEST_STATIONARY_NED(AM_NORTH_WEST_UP, QUAT_X_180)
+TEST_STATIONARY_NED(AM_WEST_NORTH_DOWN_RSD, QUAT_WEST_NORTH_DOWN_RSD_NED)
+TEST_STATIONARY_NED(AM_NE_NW_UP_RSD, QUAT_NE_NW_UP_RSD_NED)
+
 
 
 

--- a/imu_filter_madgwick/test/madgwick_test.cpp
+++ b/imu_filter_madgwick/test/madgwick_test.cpp
@@ -1,0 +1,47 @@
+#include <imu_filter_madgwick/imu_filter.h>
+#include <math.h>
+#include "test_helpers.h"
+
+#define FILTER_ITERATIONS 10000
+
+void filterStationary(
+    float Ax, float Ay, float Az,
+    float Mx, float My, float Mz,
+    double& q0, double& q1, double& q2, double& q3) {
+  float dt = 0.1;
+  float Gx = 0.0, Gy = 0.0, Gz = 0.0; // Stationary state => Gyro = (0,0,0)
+
+  ImuFilter filter;
+  filter.setDriftBiasGain(0.0);
+  filter.setAlgorithmGain(0.1);
+
+  // initialize with some orientation
+  filter.setOrientation(q0,q1,q2,q3);
+
+  for (int i = 0; i < FILTER_ITERATIONS; i++) {
+      filter.madgwickAHRSupdate(Gx, Gy, Gz, Ax, Ay, Az, Mx, My, Mz, dt);
+  }
+
+  filter.getOrientation(q0,q1,q2,q3);
+}
+
+#define TEST_STATIONARY_NWU(in_am, exp_result)       \
+  TEST(MadgwickTest, Stationary_NED_ ## in_am){      \
+    double q0 = .5, q1 = .5, q2 = .5, q3 = .5;       \
+    filterStationary(in_am, q0, q1, q2, q3);  \
+    ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+
+TEST_STATIONARY_NWU(AM_NORTH_EAST_DOWN, QUAT_X_180)
+TEST_STATIONARY_NWU(AM_NORTH_WEST_UP, QUAT_IDENTITY)
+
+// Real sensor data tests
+TEST_STATIONARY_NWU(AM_WEST_NORTH_DOWN_RSD, QUAT_WEST_NORTH_DOWN_RSD_NWU)
+TEST_STATIONARY_NWU(AM_NE_NW_UP_RSD, QUAT_NE_NW_UP_RSD_NWU)
+
+
+
+
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/imu_filter_madgwick/test/madgwick_test.cpp
+++ b/imu_filter_madgwick/test/madgwick_test.cpp
@@ -29,23 +29,58 @@ void filterStationary(
 }
 
 
+template <EarthFrame::EarthFrame FRAME>
+void filterStationary(
+    float Ax, float Ay, float Az,
+    double& q0, double& q1, double& q2, double& q3) {
+  float dt = 0.1;
+  float Gx = 0.0, Gy = 0.0, Gz = 0.0; // Stationary state => Gyro = (0,0,0)
+
+  ImuFilter filter;
+  filter.setDriftBiasGain(0.0);
+  filter.setAlgorithmGain(0.1);
+
+  // initialize with some orientation
+  filter.setOrientation(q0,q1,q2,q3);
+  filter.setEarthFrame(FRAME);
+
+  for (int i = 0; i < FILTER_ITERATIONS; i++) {
+      filter.madgwickAHRSupdateIMU(Gx, Gy, Gz, Ax, Ay, Az, dt);
+  }
+
+  filter.getOrientation(q0,q1,q2,q3);
+}
+
+
 #define TEST_STATIONARY_ENU(in_am, exp_result)       \
   TEST(MadgwickTest, Stationary_ENU_ ## in_am){      \
-    double q0 = .5, q1 = .5, q2 = .5, q3 = .5;       \
-    filterStationary<EarthFrame::ENU>(in_am, q0, q1, q2, q3);  \
-    ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+  double q0 = .5, q1 = .5, q2 = .5, q3 = .5;         \
+  filterStationary<EarthFrame::ENU>(in_am, q0, q1, q2, q3);  \
+  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }    \
+  TEST(MadgwickTest, Stationary_ENU_NM_ ## in_am){   \
+  double q0 = .5, q1 = .5, q2 = .5, q3 = .5;         \
+  filterStationary<EarthFrame::ENU>(ACCEL_ONLY(in_am), q0, q1, q2, q3);  \
+  ASSERT_QUAT_EQAL_EX_Z(q0, q1, q2, q3, exp_result); }
 
 #define TEST_STATIONARY_NED(in_am, exp_result)       \
   TEST(MadgwickTest, Stationary_NED_ ## in_am){      \
-    double q0 = .5, q1 = .5, q2 = .5, q3 = .5;       \
-    filterStationary<EarthFrame::NED>(in_am, q0, q1, q2, q3);  \
-    ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+  double q0 = .5, q1 = .5, q2 = .5, q3 = .5;         \
+  filterStationary<EarthFrame::NED>(in_am, q0, q1, q2, q3);  \
+  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }    \
+  TEST(MadgwickTest, Stationary_NED_NM_ ## in_am){   \
+  double q0 = .5, q1 = .5, q2 = .5, q3 = .5;         \
+  filterStationary<EarthFrame::NED>(ACCEL_ONLY(in_am), q0, q1, q2, q3);  \
+  ASSERT_QUAT_EQAL_EX_Z(q0, q1, q2, q3, exp_result); }
 
 #define TEST_STATIONARY_NWU(in_am, exp_result)       \
   TEST(MadgwickTest, Stationary_NWU_ ## in_am){      \
-    double q0 = .5, q1 = .5, q2 = .5, q3 = .5;       \
-    filterStationary<EarthFrame::NWU>(in_am, q0, q1, q2, q3);  \
-    ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+  double q0 = .5, q1 = .5, q2 = .5, q3 = .5;         \
+  filterStationary<EarthFrame::NWU>(in_am, q0, q1, q2, q3);  \
+  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }    \
+  TEST(MadgwickTest, Stationary_NWU_NM_ ## in_am){   \
+  double q0 = .5, q1 = .5, q2 = .5, q3 = .5;         \
+  filterStationary<EarthFrame::NWU>(ACCEL_ONLY(in_am), q0, q1, q2, q3);  \
+  ASSERT_QUAT_EQAL_EX_Z(q0, q1, q2, q3, exp_result); }
 
 TEST_STATIONARY_NWU(AM_NORTH_EAST_DOWN, QUAT_X_180)
 TEST_STATIONARY_NWU(AM_NORTH_WEST_UP, QUAT_IDENTITY)
@@ -64,6 +99,13 @@ TEST_STATIONARY_NED(AM_WEST_NORTH_DOWN_RSD, QUAT_WEST_NORTH_DOWN_RSD_NED)
 TEST_STATIONARY_NED(AM_NE_NW_UP_RSD, QUAT_NE_NW_UP_RSD_NED)
 
 
+
+TEST(MadgwickTest, TestQuatEqNoZ) {
+
+  ASSERT_TRUE(quat_eq_ex_z(QUAT_IDENTITY, QUAT_MZ_90));
+  ASSERT_FALSE(quat_eq_ex_z(QUAT_IDENTITY, QUAT_X_180));
+
+}
 
 
 

--- a/imu_filter_madgwick/test/stateless_orientation_test.cpp
+++ b/imu_filter_madgwick/test/stateless_orientation_test.cpp
@@ -1,0 +1,80 @@
+#include <imu_filter_madgwick/stateless_orientation.h>
+#include "test_helpers.h"
+
+
+template<EarthFrame::EarthFrame FRAME>
+bool computeOrientation(
+    float Ax, float Ay, float Az,
+    float Mx, float My, float Mz,
+    double& q0, double& q1, double& q2, double& q3) {
+
+  geometry_msgs::Vector3 A, M;
+  geometry_msgs::Quaternion orientation;
+  A.x = Ax; A.y = Ay; A.z = Az;
+  M.x = Mx; M.y = My; M.z = Mz;
+
+  bool res = StatelessOrientation::computeOrientation(FRAME, A, M, orientation);
+
+  q0 = orientation.w;
+  q1 = orientation.x;
+  q2 = orientation.y;
+  q3 = orientation.z;
+
+  return res;
+}
+
+
+#define TEST_STATELESS_ENU(in_am, exp_result)       \
+  TEST(StatelessOrientationTest, Stationary_ENU_ ## in_am){      \
+  double q0, q1, q2, q3;                                         \
+  ASSERT_TRUE(computeOrientation<EarthFrame::ENU>(in_am, q0, q1, q2, q3)); \
+  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+
+#define TEST_STATELESS_NED(in_am, exp_result)       \
+  TEST(StatelessOrientationTest, Stationary_NED_ ## in_am){      \
+  double q0, q1, q2, q3;                                         \
+  ASSERT_TRUE(computeOrientation<EarthFrame::NED>(in_am, q0, q1, q2, q3));  \
+  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+
+#define TEST_STATELESS_NWU(in_am, exp_result)       \
+  TEST(StatelessOrientationTest, Stationary_NWU_ ## in_am){      \
+  double q0, q1, q2, q3;                                         \
+  ASSERT_TRUE(computeOrientation<EarthFrame::NWU>(in_am, q0, q1, q2, q3));  \
+  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+
+TEST_STATELESS_ENU(AM_EAST_NORTH_UP, QUAT_IDENTITY)
+TEST_STATELESS_ENU(AM_SOUTH_UP_WEST, QUAT_XMYMZ_120)
+TEST_STATELESS_ENU(AM_SOUTH_EAST_UP, QUAT_MZ_90)
+TEST_STATELESS_ENU(AM_WEST_NORTH_DOWN_RSD, QUAT_WEST_NORTH_DOWN_RSD_ENU)
+TEST_STATELESS_ENU(AM_NE_NW_UP_RSD, QUAT_NE_NW_UP_RSD_ENU)
+
+
+TEST_STATELESS_NED(AM_NORTH_EAST_DOWN, QUAT_IDENTITY)
+TEST_STATELESS_NED(AM_WEST_NORTH_DOWN, QUAT_MZ_90)
+TEST_STATELESS_NED(AM_WEST_NORTH_DOWN_RSD, QUAT_WEST_NORTH_DOWN_RSD_NED)
+TEST_STATELESS_NED(AM_NE_NW_UP_RSD, QUAT_NE_NW_UP_RSD_NED)
+
+
+TEST_STATELESS_NWU(AM_NORTH_EAST_DOWN, QUAT_X_180)
+TEST_STATELESS_NWU(AM_NORTH_WEST_UP, QUAT_IDENTITY)
+TEST_STATELESS_NWU(AM_WEST_NORTH_DOWN_RSD, QUAT_WEST_NORTH_DOWN_RSD_NWU)
+TEST_STATELESS_NWU(AM_NE_NW_UP_RSD, QUAT_NE_NW_UP_RSD_NWU)
+
+
+TEST(StatelessOrientationTest, Check_NoAccel){
+  double q0, q1, q2, q3;
+  ASSERT_FALSE(computeOrientation<EarthFrame::ENU>(
+    0.0, 0.0, 0.0,
+    0.0, 0.0005, -0.0005,
+    q0, q1, q2, q3));
+}
+
+TEST(StatelessOrientationTest, Check_NoMag){
+  double q0, q1, q2, q3;
+  ASSERT_FALSE(computeOrientation<EarthFrame::ENU>(
+    0.0, 0.0, 9.81,
+    0.0, 0.0, 0.0,
+    q0, q1, q2, q3));
+}
+
+

--- a/imu_filter_madgwick/test/stateless_orientation_test.cpp
+++ b/imu_filter_madgwick/test/stateless_orientation_test.cpp
@@ -23,24 +23,55 @@ bool computeOrientation(
   return res;
 }
 
+template<EarthFrame::EarthFrame FRAME>
+bool computeOrientation(
+    float Ax, float Ay, float Az,
+    double& q0, double& q1, double& q2, double& q3) {
+
+  geometry_msgs::Vector3 A;
+  geometry_msgs::Quaternion orientation;
+  A.x = Ax; A.y = Ay; A.z = Az;
+
+  bool res = StatelessOrientation::computeOrientation(FRAME, A, orientation);
+
+  q0 = orientation.w;
+  q1 = orientation.x;
+  q2 = orientation.y;
+  q3 = orientation.z;
+
+  return res;
+}
+
 
 #define TEST_STATELESS_ENU(in_am, exp_result)       \
   TEST(StatelessOrientationTest, Stationary_ENU_ ## in_am){      \
   double q0, q1, q2, q3;                                         \
   ASSERT_TRUE(computeOrientation<EarthFrame::ENU>(in_am, q0, q1, q2, q3)); \
-  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }                \
+  TEST(StatelessOrientationTest, Stationary_ENU_NM_ ## in_am){   \
+  double q0, q1, q2, q3;                                         \
+  ASSERT_TRUE(computeOrientation<EarthFrame::ENU>(ACCEL_ONLY(in_am), q0, q1, q2, q3)); \
+  ASSERT_QUAT_EQAL_EX_Z(q0, q1, q2, q3, exp_result); }
 
 #define TEST_STATELESS_NED(in_am, exp_result)       \
   TEST(StatelessOrientationTest, Stationary_NED_ ## in_am){      \
   double q0, q1, q2, q3;                                         \
   ASSERT_TRUE(computeOrientation<EarthFrame::NED>(in_am, q0, q1, q2, q3));  \
-  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }                \
+  TEST(StatelessOrientationTest, Stationary_NED_NM_ ## in_am){   \
+  double q0, q1, q2, q3;                                         \
+  ASSERT_TRUE(computeOrientation<EarthFrame::NED>(ACCEL_ONLY(in_am), q0, q1, q2, q3)); \
+  ASSERT_QUAT_EQAL_EX_Z(q0, q1, q2, q3, exp_result); }
 
 #define TEST_STATELESS_NWU(in_am, exp_result)       \
   TEST(StatelessOrientationTest, Stationary_NWU_ ## in_am){      \
   double q0, q1, q2, q3;                                         \
   ASSERT_TRUE(computeOrientation<EarthFrame::NWU>(in_am, q0, q1, q2, q3));  \
-  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }
+  ASSERT_QUAT_EQAL(q0, q1, q2, q3, exp_result); }                \
+  TEST(StatelessOrientationTest, Stationary_NWU_NM_ ## in_am){   \
+  double q0, q1, q2, q3;                                         \
+  ASSERT_TRUE(computeOrientation<EarthFrame::NWU>(ACCEL_ONLY(in_am), q0, q1, q2, q3)); \
+  ASSERT_QUAT_EQAL_EX_Z(q0, q1, q2, q3, exp_result); }
 
 TEST_STATELESS_ENU(AM_EAST_NORTH_UP, QUAT_IDENTITY)
 TEST_STATELESS_ENU(AM_SOUTH_UP_WEST, QUAT_XMYMZ_120)

--- a/imu_filter_madgwick/test/test_helpers.h
+++ b/imu_filter_madgwick/test/test_helpers.h
@@ -10,7 +10,11 @@
 template <typename T>
 static inline void normalize_quaternion(T& q0, T& q1, T& q2, T& q3) {
   T invNorm = 1 / sqrt(q0*q0 + q1*q1 + q2*q2 + q3*q3);
-  if (q0 < 0) invNorm *= -1.0;
+  T max = q0;
+  if (fabs(max) < fabs(q1)) max = q1;
+  if (fabs(max) < fabs(q2)) max = q2;
+  if (fabs(max) < fabs(q3)) max = q3;
+  if (max < 0) invNorm *= -1.0;
 
   q0 *= invNorm;
   q1 *= invNorm;
@@ -54,7 +58,11 @@ static inline bool quat_equal(T q0, T q1, T q2, T q3, T qr0, T qr1, T qr2, T qr3
 #define QUAT_X_180 0.0, 1.0, 0.0, 0.0
 #define QUAT_XMYMZ_120 0.5, 0.5, -0.5, -0.5
 #define QUAT_WEST_NORTH_DOWN_RSD_NWU 0.01, 0.86, 0.50, 0.012 /* axis: (0.864401, 0.502559, 0.0120614) | angle: 178.848deg */
+#define QUAT_WEST_NORTH_DOWN_RSD_ENU 0.0, -0.25, -0.97, -0.02/* Axis: (-0.2, -0.96, 0.02), Angle: 180deg */
+#define QUAT_WEST_NORTH_DOWN_RSD_NED 0.86, -0.01, 0.01, -0.50 /* Axis: -Z, Angle: 60deg */
 #define QUAT_NE_NW_UP_RSD_NWU 0.91, 0.03, -0.02, -0.41 /* axis: (0.0300376, -0.020025, -0.410513) | angle: 48.6734deg */
+#define QUAT_NE_NW_UP_RSD_ENU 0.93, 0.03, 0.0, 0.35 /* Axis: Z,  Angle: 41deg */
+#define QUAT_NE_NW_UP_RSD_NED 0.021, -0.91, -0.41, 0.02 /* Axis: (0.9, 0.4, 0.0), Angle: 180deg */
 
 
 #endif /* TEST_TEST_HELPERS_H_ */

--- a/imu_filter_madgwick/test/test_helpers.h
+++ b/imu_filter_madgwick/test/test_helpers.h
@@ -3,9 +3,9 @@
 #define TEST_TEST_HELPERS_H_
 
 #include <gtest/gtest.h>
-#include <geometry_msgs/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.h>
 
-#define MAX_DIFF 0.01
+#define MAX_DIFF 0.05
 
 template <typename T>
 static inline void normalize_quaternion(T& q0, T& q1, T& q2, T& q3) {
@@ -27,15 +27,38 @@ template <typename T>
 static inline bool quat_equal(T q0, T q1, T q2, T q3, T qr0, T qr1, T qr2, T qr3) {
   normalize_quaternion(q0, q1, q2, q3);
   normalize_quaternion(qr0, qr1, qr2, qr3);
+
   return (fabs(q0 - qr0) < MAX_DIFF) &&
          (fabs(q1 - qr1) < MAX_DIFF) &&
          (fabs(q2 - qr2) < MAX_DIFF) &&
          (fabs(q3 - qr3) < MAX_DIFF);
 }
 
+template <typename T>
+static inline bool quat_eq_ex_z(T q0, T q1, T q2, T q3, T qr0, T qr1, T qr2, T qr3) {
+  // assert q == qr * qz
+  tf2::Quaternion q(q1, q2, q3, q0);
+  tf2::Quaternion qr(qr1, qr2, qr3, qr0);
+  tf2::Quaternion qz = q * qr.inverse();
+
+  // remove x and y components.
+  qz.setX(0.0);
+  qz.setY(0.0);
+
+  tf2::Quaternion qr_ = qz * qr;
+
+  return quat_equal(q0, q1, q2, q3,
+      qr_.getW(),
+      qr_.getX(),
+      qr_.getY(),
+      qr_.getZ());
+}
+
 #define ASSERT_QUAT_EQAL_(q0, q1, q2, q3, qr0, qr1, qr2, qr3) ASSERT_TRUE(quat_equal(q0, q1, q2, q3, qr0, qr1, qr2, qr3)) << "q0: " << q0 << ", q1: " << q1 << ", q2: " << q2 << ", q3: " << q3;
 #define ASSERT_QUAT_EQAL(...) ASSERT_QUAT_EQAL_(__VA_ARGS__)
 
+#define ASSERT_QUAT_EQAL_EX_Z_(q0, q1, q2, q3, qr0, qr1, qr2, qr3) ASSERT_TRUE(quat_eq_ex_z(q0, q1, q2, q3, qr0, qr1, qr2, qr3)) << "q0: " << q0 << ", q1: " << q1 << ", q2: " << q2 << ", q3: " << q3;
+#define ASSERT_QUAT_EQAL_EX_Z(...) ASSERT_QUAT_EQAL_EX_Z_(__VA_ARGS__)
 
 // Well known states
 // scheme: AM_x_y_z
@@ -50,6 +73,8 @@ static inline bool quat_equal(T q0, T q1, T q2, T q3, T qr0, T qr1, T qr2, T qr3
 #define AM_WEST_NORTH_DOWN_RSD /* Acceleration */ 0.12, 0.29, -9.83, /* Magnetic */ 6.363e-06, 1.0908e-05, 4.2723e-05
 #define AM_NE_NW_UP_RSD   /* Acceleration */ 0.20, 0.55, 9.779, /* Magnetic */ 8.484e-06, 8.181e-06, -4.3329e-05
 
+// Strip accelration from am
+#define ACCEL_ONLY(ax,ay,az, mx,my,mz) ax, ay, az
 
 // Well known quaternion
 // scheme: QUAT_axis_angle

--- a/imu_filter_madgwick/test/test_helpers.h
+++ b/imu_filter_madgwick/test/test_helpers.h
@@ -1,0 +1,60 @@
+
+#ifndef TEST_TEST_HELPERS_H_
+#define TEST_TEST_HELPERS_H_
+
+#include <gtest/gtest.h>
+#include <geometry_msgs/Quaternion.h>
+
+#define MAX_DIFF 0.01
+
+template <typename T>
+static inline void normalize_quaternion(T& q0, T& q1, T& q2, T& q3) {
+  T invNorm = 1 / sqrt(q0*q0 + q1*q1 + q2*q2 + q3*q3);
+  if (q0 < 0) invNorm *= -1.0;
+
+  q0 *= invNorm;
+  q1 *= invNorm;
+  q2 *= invNorm;
+  q3 *= invNorm;
+}
+
+
+template <typename T>
+static inline bool quat_equal(T q0, T q1, T q2, T q3, T qr0, T qr1, T qr2, T qr3) {
+  normalize_quaternion(q0, q1, q2, q3);
+  normalize_quaternion(qr0, qr1, qr2, qr3);
+  return (fabs(q0 - qr0) < MAX_DIFF) &&
+         (fabs(q1 - qr1) < MAX_DIFF) &&
+         (fabs(q2 - qr2) < MAX_DIFF) &&
+         (fabs(q3 - qr3) < MAX_DIFF);
+}
+
+#define ASSERT_QUAT_EQAL_(q0, q1, q2, q3, qr0, qr1, qr2, qr3) ASSERT_TRUE(quat_equal(q0, q1, q2, q3, qr0, qr1, qr2, qr3)) << "q0: " << q0 << ", q1: " << q1 << ", q2: " << q2 << ", q3: " << q3;
+#define ASSERT_QUAT_EQAL(...) ASSERT_QUAT_EQAL_(__VA_ARGS__)
+
+
+// Well known states
+// scheme: AM_x_y_z
+#define AM_EAST_NORTH_UP    /* Acceleration */ 0.0, 0.0, 9.81,  /* Magnetic */ 0.0, 0.0005, -0.0005
+#define AM_NORTH_EAST_DOWN  /* Acceleration */ 0.0, 0.0, -9.81, /* Magnetic */ 0.0005, 0.0, 0.0005
+#define AM_NORTH_WEST_UP    /* Acceleration */ 0.0, 0.0, 9.81,  /* Magnetic */ 0.0005, 0.0, -0.0005
+#define AM_SOUTH_UP_WEST    /* Acceleration */ 0.0, 9.81, 0.0,  /* Magnetic */ -0.0005, -0.0005, 0.0
+#define AM_SOUTH_EAST_UP    /* Acceleration */ 0.0, 0.0, 9.81,  /* Magnetic */ -0.0005, 0.0, -0.0005
+#define AM_WEST_NORTH_DOWN  /* Acceleration */ 0.0, 0.0, -9.81, /* Magnetic */ 0.0, 0.0005, 0.0005
+
+// Real sensor data
+#define AM_WEST_NORTH_DOWN_RSD /* Acceleration */ 0.12, 0.29, -9.83, /* Magnetic */ 6.363e-06, 1.0908e-05, 4.2723e-05
+#define AM_NE_NW_UP_RSD   /* Acceleration */ 0.20, 0.55, 9.779, /* Magnetic */ 8.484e-06, 8.181e-06, -4.3329e-05
+
+
+// Well known quaternion
+// scheme: QUAT_axis_angle
+#define QUAT_IDENTITY  1.0, 0.0, 0.0, 0.0
+#define QUAT_MZ_90 0.5, 0.0, 0.0, -0.5
+#define QUAT_X_180 0.0, 1.0, 0.0, 0.0
+#define QUAT_XMYMZ_120 0.5, 0.5, -0.5, -0.5
+#define QUAT_WEST_NORTH_DOWN_RSD_NWU 0.01, 0.86, 0.50, 0.012 /* axis: (0.864401, 0.502559, 0.0120614) | angle: 178.848deg */
+#define QUAT_NE_NW_UP_RSD_NWU 0.91, 0.03, -0.02, -0.41 /* axis: (0.0300376, -0.020025, -0.410513) | angle: 48.6734deg */
+
+
+#endif /* TEST_TEST_HELPERS_H_ */


### PR DESCRIPTION
Here's an ENU implementation of the the algorithm (#36).
There's also a matrix implementation of the initial orientation computation, which should be more stable than the RPY implementation.

I removed the micro optimizations, hoping the compiler does that job. The "static inline" methods should force compiler optimization while keeping the code easy to read and maintain.

Not tested yet, only for review.

What's missing:
- Switch between ENU / NED by parameter
- Provide computeOrientation in reusable library
