### PR TITLE
Add option to display orientation in world frame

### DIFF
--- a/rviz_imu_plugin/src/imu_display.h
+++ b/rviz_imu_plugin/src/imu_display.h
@@ -110,6 +110,7 @@ public:
 
 protected Q_SLOTS:
 
+    void updateTop();
     void updateBox();
     void updateAxes();
     void updateAcc();
@@ -117,6 +118,7 @@ protected Q_SLOTS:
 private:
 
     // Property objects for user-editable properties.
+    rviz::BoolProperty*  fixed_frame_orientation_property_;
 
     rviz::Property* box_category_;
     rviz::Property* axes_category_;
@@ -146,6 +148,7 @@ private:
 
     // User-editable property variables.
     std::string topic_;
+    bool fixed_frame_orientation_;
     bool box_enabled_;
     bool axes_enabled_;
     bool acc_enabled_;


### PR DESCRIPTION
Per REP 145 IMU orientation is in the world frame. Rotating the
orientation data to transform into the sensor frame results in strange
behavior, such as double-rotation of orientation on a robot. Provide an
option to display orientatoin in the world frame, and enable it by
default. Continue to translate the position of the data to the sensor
frame.