### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/imu_filter_madgwick/src/imu_filter_nodelet.cpp
+++ b/imu_filter_madgwick/src/imu_filter_nodelet.cpp
@@ -36,4 +36,4 @@ void ImuFilterNodelet::onInit()
   filter_.reset(new ImuFilterRos(nh, nh_private));
 }
 
-PLUGINLIB_DECLARE_CLASS(imu_filter_madgwick, ImuFilterNodelet, ImuFilterNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(ImuFilterNodelet, nodelet::Nodelet)


### PR DESCRIPTION
This macro, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)
