### PR TITLE
[rviz_imu_plugin] print ros_warn and give unit quaternion to ogre to …

### DIFF
--- a/rviz_imu_plugin/src/imu_acc_visual.h
+++ b/rviz_imu_plugin/src/imu_acc_visual.h
@@ -95,7 +95,7 @@ class ImuAccVisual
     QColor color_;
 
     bool derotated_;
- 
+
     // A SceneNode whose pose is set to match the coordinate frame of
     // the Imu message header.
     Ogre::SceneNode * frame_node_;

--- a/rviz_imu_plugin/src/imu_axes_visual.cpp
+++ b/rviz_imu_plugin/src/imu_axes_visual.cpp
@@ -30,12 +30,14 @@
 
 #include "imu_axes_visual.h"
 
+#include <ros/ros.h>
+
 namespace rviz
 {
 
 ImuAxesVisual::ImuAxesVisual(Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node):
   orientation_axes_(NULL),
-  scale_(0.15)
+  scale_(0.15), quat_valid_(true)
 {
   scene_manager_ = scene_manager;
 
@@ -78,19 +80,35 @@ void ImuAxesVisual::hide()
 
 void ImuAxesVisual::setMessage(const sensor_msgs::Imu::ConstPtr& msg)
 {
-  orientation_ = Ogre::Quaternion(msg->orientation.w,
-                                  msg->orientation.x,
-                                  msg->orientation.y,
-                                  msg->orientation.z);
+  if (checkQuaterinonValidity(msg)) {
+    if (!quat_valid_) {
+      ROS_INFO("rviz_imu_plugin axes get valid quaternion, "
+               "axes show recovered");
+      quat_valid_ = true;
+    }
+    orientation_ = Ogre::Quaternion(msg->orientation.w,
+                                    msg->orientation.x,
+                                    msg->orientation.y,
+                                    msg->orientation.z);
+  } else {
+    if (quat_valid_) {
+      ROS_WARN("rviz_imu_plugin axes get invalid quaternion (%lf, %lf, %lf, %lf), "
+               "change orientation to fixed unit", msg->orientation.w,
+               msg->orientation.x,msg->orientation.y,msg->orientation.z);
+      quat_valid_ = false;
+    }
+    // if quaternion is invalid, give a unit quat to Ogre
+    orientation_ = Ogre::Quaternion();
+  }
 
-  if (orientation_axes_) 
+  if (orientation_axes_)
     orientation_axes_->setOrientation(orientation_);
 }
 
-void ImuAxesVisual::setScale(float scale) 
-{ 
-  scale_ = scale; 
-  if (orientation_axes_) 
+void ImuAxesVisual::setScale(float scale)
+{
+  scale_ = scale;
+  if (orientation_axes_)
    orientation_axes_->setScale(Ogre::Vector3(scale_, scale_, scale_));
 }
 
@@ -103,6 +121,23 @@ void ImuAxesVisual::setFrameOrientation(const Ogre::Quaternion& orientation)
 {
   frame_node_->setOrientation(orientation);
 }
+
+inline bool ImuAxesVisual::checkQuaterinonValidity(
+    const sensor_msgs::Imu::ConstPtr& msg) {
+
+  double x = msg->orientation.x,
+         y = msg->orientation.y,
+         z = msg->orientation.z,
+         w = msg->orientation.w;
+  // OGRE could handle unnormalized quaternion, but quat's length extremely small
+  // may indicates that invalid (0, 0, 0, 0) quat is passed, this will lead ogre
+  // crash unexpectly
+  if ( std::sqrt( x*x + y*y + z*z + w*w ) < 0.0001 ) {
+    return false;
+  }
+  return true;
+}
+
 
 } // end namespace rviz
 

--- a/rviz_imu_plugin/src/imu_axes_visual.h
+++ b/rviz_imu_plugin/src/imu_axes_visual.h
@@ -74,13 +74,16 @@ class ImuAxesVisual
   private:
 
     void create();
+    inline bool checkQuaterinonValidity(
+        const sensor_msgs::Imu::ConstPtr& msg);
 
     Ogre::Quaternion orientation_;
 
     float scale_;
+    bool quat_valid_;
 
     Axes * orientation_axes_;
-  
+
     // A SceneNode whose pose is set to match the coordinate frame of
     // the Imu message header.
     Ogre::SceneNode * frame_node_;

--- a/rviz_imu_plugin/src/imu_display.h
+++ b/rviz_imu_plugin/src/imu_display.h
@@ -73,7 +73,7 @@ public:
     virtual void reset();
     virtual void createProperties();
 
-    void setTopic(const std::string& topic);
+    //void setTopic(const std::string& topic);
     const std::string& getTopic() { return topic_; }
 
     void setBoxEnabled(bool enabled);

--- a/rviz_imu_plugin/src/imu_orientation_visual.h
+++ b/rviz_imu_plugin/src/imu_orientation_visual.h
@@ -81,15 +81,18 @@ class ImuOrientationVisual
   private:
 
     void create();
+    inline bool checkQuaterinonValidity(
+        const sensor_msgs::Imu::ConstPtr& msg);
 
     Ogre::Quaternion orientation_;
 
     float scale_x_, scale_y_, scale_z_;
     QColor color_;
     float alpha_;
+    bool quat_valid_;
 
     Shape * orientation_box_;
-  
+
     // A SceneNode whose pose is set to match the coordinate frame of
     // the Imu message header.
     Ogre::SceneNode * frame_node_;


### PR DESCRIPTION
This pr is for [rviz_imu_plugin]
As mentioned in [#issue86](https://github.com/ccny-ros-pkg/imu_tools/issues/86#issuecomment-418623933). Add a ROS warn message when invalid orientation imu data passed to the plugin and convert it to a unit quaternion to prevent rviz crash. When valid imu data is given, display will recover. 

There is a rosbag test data [rviz_imu_test.bag](https://drive.google.com/file/d/1sa4LjdIUcje_wqyz6rrAEkOrT4UEvOX1/view?usp=sharingl). The data begin with valid orientation, after few seconds, invalid data was passed. Few seconds later valid message is passed again. 

