### PR TITLE
[windows][melodic] imu_tools bring-up on Windows

### DIFF
--- a/imu_complementary_filter/CMakeLists.txt
+++ b/imu_complementary_filter/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(imu_complementary_filter)
 
+find_package(Boost REQUIRED COMPONENTS thread)
+
 find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   message_filters
@@ -19,6 +21,7 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 
 ## Declare a cpp library
@@ -28,6 +31,7 @@ add_library(complementary_filter
   include/imu_complementary_filter/complementary_filter.h
   include/imu_complementary_filter/complementary_filter_ros.h
 )
+target_link_libraries(complementary_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 
 # create complementary_filter_node executable
@@ -35,7 +39,13 @@ add_executable(complementary_filter_node
   src/complementary_filter_node.cpp)
 target_link_libraries(complementary_filter_node complementary_filter ${catkin_LIBRARIES})
 
-install(TARGETS complementary_filter complementary_filter_node
+install(TARGETS complementary_filter
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(TARGETS complementary_filter_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/imu_filter_madgwick/CMakeLists.txt
+++ b/imu_filter_madgwick/CMakeLists.txt
@@ -39,10 +39,16 @@ add_dependencies(imu_filter_node ${PROJECT_NAME}_gencfg)
 target_link_libraries(imu_filter_node imu_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 
-install(TARGETS imu_filter imu_filter_nodelet imu_filter_node
+install(TARGETS imu_filter_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(TARGETS imu_filter imu_filter_nodelet
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
 )
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/rviz_imu_plugin/CMakeLists.txt
+++ b/rviz_imu_plugin/CMakeLists.txt
@@ -47,6 +47,8 @@ set(SRC_FILES  src/imu_display.cpp
 ## Build libraries
 add_library(${PROJECT_NAME} ${SRC_FILES})
 
+set_target_properties(${PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 ## Link the library with whatever Qt libraries have been defined by
 ## the ``find_package(Qt4 ...)`` line above, or by the
 ## ``set(QT_LIBRARIES Qt5::Widgets)``, and with whatever libraries


### PR DESCRIPTION
This pull request is to address issues when we are attempting to build & run it on `Windows`.

* Follow `catkin` guide to install the shared libraries and executables to portable location:
  https://docs.ros.org/api/catkin/html/howto/format1/building_libraries.html
  https://docs.ros.org/api/catkin/html/howto/format1/building_executables.html

* Add explicit dependencies to `Boost thread` module. On `Windows`, it is required for linkage stage.

* Explicitly expose the symbols from ` rviz_imu_plugin` from its shared library, so it can be loaded at runtime as plugin.

(It is tested against https://aka.ms/ros project.)