### PR TITLE
Add the option to remove the gravity vector.

### DIFF
--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
@@ -44,7 +44,7 @@ class ImuFilter
 
     // **** state variables
     double q0, q1, q2, q3;  // quaternion
-    float w_bx_, w_by_, w_bz_; // 
+    float w_bx_, w_by_, w_bz_; //
 
 public:
     void setAlgorithmGain(double gain)
@@ -99,6 +99,9 @@ public:
     void madgwickAHRSupdateIMU(float gx, float gy, float gz,
                                float ax, float ay, float az,
                                float dt);
+
+    void getGravity(float& rx, float& ry, float& rz,
+                    float gravity = 9.80665);
 };
 
 #endif // IMU_FILTER_IMU_MADWICK_FILTER_H

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
@@ -85,6 +85,7 @@ class ImuFilterRos
     std::string imu_frame_;
     double constant_dt_;
     bool publish_debug_topics_;
+    bool remove_gravity_vector_;
     geometry_msgs::Vector3 mag_bias_;
     double orientation_variance_;
 

--- a/imu_filter_madgwick/src/imu_filter.cpp
+++ b/imu_filter_madgwick/src/imu_filter.cpp
@@ -309,3 +309,31 @@ void ImuFilter::madgwickAHRSupdateIMU(
   // Normalise quaternion
   normalizeQuaternion (q0, q1, q2, q3);
 }
+
+
+void ImuFilter::getGravity(float& rx, float& ry, float& rz,
+    float gravity)
+{
+    // Estimate gravity vector from current orientation
+    switch (world_frame_) {
+      case WorldFrame::NED:
+        // Gravity: [0, 0, -1]
+        rotateAndScaleVector(q0, q1, q2, q3,
+            0.0, 0.0, -2.0*gravity,
+            rx, ry, rz);
+        break;
+      case WorldFrame::NWU:
+        // Gravity: [0, 0, 1]
+        rotateAndScaleVector(q0, q1, q2, q3,
+            0.0, 0.0, 2.0*gravity,
+            rx, ry, rz);
+        break;
+      default:
+      case WorldFrame::ENU:
+        // Gravity: [0, 0, 1]
+        rotateAndScaleVector(q0, q1, q2, q3,
+            0.0, 0.0, 2.0*gravity,
+            rx, ry, rz);
+        break;
+    }
+}

--- a/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -48,6 +48,8 @@ ImuFilterRos::ImuFilterRos(ros::NodeHandle nh, ros::NodeHandle nh_private):
    fixed_frame_ = "odom";
   if (!nh_private_.getParam ("constant_dt", constant_dt_))
     constant_dt_ = 0.0;
+  if (!nh_private_.getParam ("remove_gravity_vector", remove_gravity_vector_))
+    remove_gravity_vector_= false;
   if (!nh_private_.getParam ("publish_debug_topics", publish_debug_topics_))
     publish_debug_topics_= false;
 
@@ -81,6 +83,11 @@ ImuFilterRos::ImuFilterRos(ros::NodeHandle nh, ros::NodeHandle nh_private):
     ROS_INFO("Using dt computed from message headers");
   else
     ROS_INFO("Using constant dt of %f sec", constant_dt_);
+
+  if (remove_gravity_vector_)
+    ROS_INFO("The gravity vector will be removed from the acceleration");
+  else
+    ROS_INFO("The gravity vector is kept in the IMU message.");
 
   // **** register dynamic reconfigure
   config_server_.reset(new FilterConfigServer(nh_private_));
@@ -324,6 +331,15 @@ void ImuFilterRos::publishFilteredMsg(const ImuMsg::ConstPtr& imu_msg_raw)
   imu_msg->orientation_covariance[6] = 0.0;
   imu_msg->orientation_covariance[7] = 0.0;
   imu_msg->orientation_covariance[8] = orientation_variance_;
+
+
+  if(remove_gravity_vector_) {
+    float gx, gy, gz;
+    filter_.getGravity(gx, gy, gz);
+    imu_msg->linear_acceleration.x -= gx;
+    imu_msg->linear_acceleration.y -= gy;
+    imu_msg->linear_acceleration.z -= gz;
+  }
 
   imu_publisher_.publish(imu_msg);
 


### PR DESCRIPTION
The following code allows removing the gravity vector from the imu as an option.

This is implemented by adding a "getGravity" function to the filter which returns the [0,0,9.9.80665] rotated by the latest quaternion of the filter. This gravity is then removed from the acceleration before re-publishing if the `remove_gravity_vector` parameter is set to true (default false)