### PR TITLE
Change to allow the usage of imu_filter_madgwick as a library

### DIFF
--- a/imu_filter_madgwick/CMakeLists.txt
+++ b/imu_filter_madgwick/CMakeLists.txt
@@ -56,9 +56,6 @@ install(DIRECTORY
   launch config
   DESTINATION share/${PROJECT_NAME})
 
-install(DIRECTORY
-  include
-  DESTINATION include)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/imu_filter_madgwick/CMakeLists.txt
+++ b/imu_filter_madgwick/CMakeLists.txt
@@ -56,6 +56,10 @@ install(DIRECTORY
   launch config
   DESTINATION share/${PROJECT_NAME})
 
+install(DIRECTORY
+  include
+  DESTINATION include)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   add_subdirectory(test)
@@ -63,5 +67,10 @@ endif()
 
 ament_export_include_directories(include)
 ament_export_libraries(imu_filter_madgwick)
+
+install(
+  DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION include/${PROJECT_NAME}
+)
 
 ament_package()

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
@@ -52,7 +52,8 @@ class ImuFilterMadgwickRos : public imu_filter::BaseNode {
 
 public:
   explicit ImuFilterMadgwickRos(const rclcpp::NodeOptions &options);
-
+  void imuCallback(ImuMsg::ConstSharedPtr imu_msg_raw);
+  
 private:
   std::shared_ptr<ImuSubscriber> imu_subscriber_;
   std::shared_ptr<MagSubscriber> mag_subscriber_;
@@ -96,7 +97,7 @@ private:
   // **** member functions
   void imuMagCallback(ImuMsg::ConstSharedPtr imu_msg_raw, MagMsg::ConstSharedPtr mag_msg);
 
-  void imuCallback(ImuMsg::ConstSharedPtr imu_msg_raw);
+  
 
   void publishFilteredMsg(ImuMsg::ConstSharedPtr imu_msg_raw);
   void publishTransform(ImuMsg::ConstSharedPtr imu_msg_raw);

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
@@ -52,7 +52,10 @@ class ImuFilterMadgwickRos : public imu_filter::BaseNode {
 
 public:
   explicit ImuFilterMadgwickRos(const rclcpp::NodeOptions &options);
+  
+  //Callbacks are public for manual operation (without callback)
   void imuCallback(ImuMsg::ConstSharedPtr imu_msg_raw);
+  void imuMagCallback(ImuMsg::ConstSharedPtr imu_msg_raw, MagMsg::ConstSharedPtr mag_msg);
   
 private:
   std::shared_ptr<ImuSubscriber> imu_subscriber_;
@@ -95,7 +98,6 @@ private:
   ImuFilter filter_;
 
   // **** member functions
-  void imuMagCallback(ImuMsg::ConstSharedPtr imu_msg_raw, MagMsg::ConstSharedPtr mag_msg);
 
   
 


### PR DESCRIPTION
Fix a bug where include directories would not install when compiled with colcon.

Missing these
```sh
install(
  DIRECTORY include/${PROJECT_NAME}/
  DESTINATION include/${PROJECT_NAME}
)
```

Changing the visibility of `void imuCallback(ImuMsg::ConstSharedPtr imu_msg_raw);` so the code can be used without subscribers(manual mode).