### PR TITLE
Enable on Windows

### DIFF
--- a/imu_filter_madgwick/CMakeLists.txt
+++ b/imu_filter_madgwick/CMakeLists.txt
@@ -35,6 +35,8 @@ ament_target_dependencies(imu_filter_madgwick
   tf2_ros
 )
 rclcpp_components_register_nodes(imu_filter_madgwick "ImuFilterMadgwickRos")
+target_compile_definitions(imu_filter_madgwick
+  PRIVATE "IMU_FILTER_MADGWICK_CPP_BUILDING_DLL")
 
 add_executable(imu_filter_madgwick_node src/imu_filter_node.cpp)
 target_link_libraries(imu_filter_madgwick_node imu_filter_madgwick)

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
@@ -37,6 +37,7 @@
 
 #include "imu_filter_madgwick/imu_filter.h"
 #include "imu_filter_madgwick/base_node.hpp"
+#include "imu_filter_madgwick/visibility_control.h"
 
 class ImuFilterMadgwickRos : public imu_filter::BaseNode
 {
@@ -51,6 +52,8 @@ class ImuFilterMadgwickRos : public imu_filter::BaseNode
     typedef message_filters::Subscriber<MagMsg> MagSubscriber;
 
   public:
+  
+    IMU_FILTER_MADGWICK_CPP_PUBLIC
     explicit ImuFilterMadgwickRos(const rclcpp::NodeOptions& options);
 
     // Callbacks are public so they can be called when used as a library

--- a/imu_filter_madgwick/include/imu_filter_madgwick/visibility_control.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IMU_FILTER_MADGWICK_CPP__VISIBILITY_CONTROL_H_
+#define IMU_FILTER_MADGWICK_CPP__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define IMU_FILTER_MADGWICK_CPP_EXPORT __attribute__ ((dllexport))
+    #define IMU_FILTER_MADGWICK_CPP_IMPORT __attribute__ ((dllimport))
+  #else
+    #define IMU_FILTER_MADGWICK_CPP_EXPORT __declspec(dllexport)
+    #define IMU_FILTER_MADGWICK_CPP_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef IMU_FILTER_MADGWICK_CPP_BUILDING_DLL
+    #define IMU_FILTER_MADGWICK_CPP_PUBLIC IMU_FILTER_MADGWICK_CPP_EXPORT
+  #else
+    #define IMU_FILTER_MADGWICK_CPP_PUBLIC IMU_FILTER_MADGWICK_CPP_IMPORT
+  #endif
+  #define IMU_FILTER_MADGWICK_CPP_PUBLIC_TYPE IMU_FILTER_MADGWICK_CPP_PUBLIC
+  #define IMU_FILTER_MADGWICK_CPP_LOCAL
+#else
+  #define IMU_FILTER_MADGWICK_CPP_EXPORT __attribute__ ((visibility("default")))
+  #define IMU_FILTER_MADGWICK_CPP_IMPORT
+  #if __GNUC__ >= 4
+    #define IMU_FILTER_MADGWICK_CPP_PUBLIC __attribute__ ((visibility("default")))
+    #define IMU_FILTER_MADGWICK_CPP_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define IMU_FILTER_MADGWICK_CPP_PUBLIC
+    #define IMU_FILTER_MADGWICK_CPP_LOCAL
+  #endif
+  #define IMU_FILTER_MADGWICK_CPP_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // IMU_FILTER_MADGWICK_CPP__VISIBILITY_CONTROL_H_

--- a/imu_filter_madgwick/test/CMakeLists.txt
+++ b/imu_filter_madgwick/test/CMakeLists.txt
@@ -1,5 +1,7 @@
-ament_add_gtest(madgwick_test madgwick_test.cpp)
-target_link_libraries(madgwick_test imu_filter_madgwick)
+if(NOT WIN32)
+    ament_add_gtest(madgwick_test madgwick_test.cpp)
+    target_link_libraries(madgwick_test imu_filter_madgwick)
 
-ament_add_gtest(stateless_orientation_test stateless_orientation_test.cpp)
-target_link_libraries(stateless_orientation_test imu_filter_madgwick)
+    ament_add_gtest(stateless_orientation_test stateless_orientation_test.cpp)
+    target_link_libraries(stateless_orientation_test imu_filter_madgwick)
+endif()


### PR DESCRIPTION
Thank you for these wonderful tools!

This change adds support for building on Windows. Windows symbols are private by default and have to be explicitly exposed. The ROS2 recommendation is to use a visibility_control header, which was added. During the build of the ROS node, you also need to set a build flag to indicate a dll is being built - which has also been added.