### PR TITLE
Remove node_ prefix.

### DIFF
--- a/imu_complementary_filter/launch/complementary_filter.launch.py
+++ b/imu_complementary_filter/launch/complementary_filter.launch.py
@@ -7,7 +7,7 @@ def generate_launch_description():
         [
             Node(
                 package='imu_complementary_filter',
-                node_executable='complementary_filter_node',
+                executable='complementary_filter_node',
                 name='complementary_filter_gain_node',
                 output='screen',
                 parameters=[

--- a/imu_filter_madgwick/launch/imu_filter.launch.py
+++ b/imu_filter_madgwick/launch/imu_filter.launch.py
@@ -14,8 +14,8 @@ def generate_launch_description():
         [
             launch_ros.actions.Node(
                 package='imu_filter_madgwick',
-                node_executable='imu_filter_madgwick_node',
-                node_name='imu_filter',
+                executable='imu_filter_madgwick_node',
+                name='imu_filter',
                 output='screen',
                 parameters=[os.path.join(config_dir, 'imu_filter.yaml')],
             )

--- a/imu_filter_madgwick/launch/imu_filter_component.launch.py
+++ b/imu_filter_madgwick/launch/imu_filter_component.launch.py
@@ -21,15 +21,15 @@ def generate_launch_description():
         params = yaml.safe_load(f)['imu_filter']['ros__parameters']
 
     container = ComposableNodeContainer(
-        node_name='imu_filter_container',
-        node_namespace='',
+        name='imu_filter_container',
+        namespace='',
         package='rclcpp_components',
-        node_executable='component_container',
+        executable='component_container',
         composable_node_descriptions=[
             ComposableNode(
                 package='imu_filter_madgwick',
-                node_plugin='ImuFilterMadgwickRos',
-                node_name='imu_filter',
+                plugin='ImuFilterMadgwickRos',
+                name='imu_filter',
                 parameters=[params],
             )
         ],


### PR DESCRIPTION
The launch files of both filters would not start with ROS Humble due to the use of deprecated prefixes node_
