### PR TITLE
Added ability to reset IMU filters when ROS time jumps back

### DIFF
--- a/imu_complementary_filter/include/imu_complementary_filter/complementary_filter.h
+++ b/imu_complementary_filter/include/imu_complementary_filter/complementary_filter.h
@@ -87,6 +87,9 @@ class ComplementaryFilter
     void update(double ax, double ay, double az, double wx, double wy,
                 double wz, double mx, double my, double mz, double dt);
 
+    // Reset the filter to the initial state.
+    void reset();
+
   private:
     static const double kGravity;
     static const double gamma_;

--- a/imu_complementary_filter/include/imu_complementary_filter/complementary_filter_ros.h
+++ b/imu_complementary_filter/include/imu_complementary_filter/complementary_filter_ros.h
@@ -55,6 +55,9 @@ class ComplementaryFilterROS
                            const ros::NodeHandle& nh_private);
     virtual ~ComplementaryFilterROS();
 
+    // Reset the filter to the initial state.
+    void reset();
+
   private:
     // Convenience typedefs
     typedef sensor_msgs::Imu ImuMsg;
@@ -89,10 +92,12 @@ class ComplementaryFilterROS
     bool publish_debug_topics_;
     std::string fixed_frame_;
     double orientation_variance_;
+    ros::Duration time_jump_threshold_;
 
     // State variables:
     ComplementaryFilter filter_;
     ros::Time time_prev_;
+    ros::Time last_ros_time_;
     bool initialized_filter_;
 
     void initializeParams();
@@ -103,6 +108,8 @@ class ComplementaryFilterROS
 
     tf::Quaternion hamiltonToTFQuaternion(double q0, double q1, double q2,
                                           double q3) const;
+    // Check whether ROS time has jumped back. If so, reset the filter.
+    void checkTimeJump();
 };
 
 }  // namespace imu_tools

--- a/imu_complementary_filter/src/complementary_filter.cpp
+++ b/imu_complementary_filter/src/complementary_filter.cpp
@@ -456,6 +456,16 @@ double ComplementaryFilter::getAdaptiveGain(double alpha, double ax, double ay,
     return factor * alpha;
 }
 
+void ComplementaryFilter::reset()
+{
+    initialized_ = false;
+    steady_state_ = false;
+    q0_ = 1.0;
+    q1_ = q2_ = q3_ = 0.0;
+    wx_bias_ = wy_bias_ = wz_bias_ = 0.0;
+    wx_prev_ = wy_prev_ = wz_prev_ = 0.0;
+}
+
 void normalizeVector(double& x, double& y, double& z)
 {
     double norm = sqrt(x * x + y * y + z * z);

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter.h
@@ -97,6 +97,9 @@ class ImuFilter
                                float az, float dt);
 
     void getGravity(float& rx, float& ry, float& rz, float gravity = 9.80665);
+
+    //! \brief Reset the filter to the initial state.
+    void reset();
 };
 
 #endif  // IMU_FILTER_IMU_MADWICK_FILTER_H

--- a/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/imu_filter_ros.h
@@ -57,6 +57,9 @@ class ImuFilterRos
     ImuFilterRos(ros::NodeHandle nh, ros::NodeHandle nh_private);
     virtual ~ImuFilterRos();
 
+    //! \brief Reset the filter to the initial state.
+    void reset();
+
   private:
     // **** ROS-related
 
@@ -90,11 +93,13 @@ class ImuFilterRos
     bool remove_gravity_vector_;
     geometry_msgs::Vector3 mag_bias_;
     double orientation_variance_;
+    ros::Duration time_jump_threshold_;
 
     // **** state variables
     boost::mutex mutex_;
     bool initialized_;
     ros::Time last_time_;
+    ros::Time last_ros_time_;
 
     // **** filter implementation
     ImuFilter filter_;
@@ -114,6 +119,8 @@ class ImuFilterRos
     void checkTopicsTimerCallback(const ros::TimerEvent&);
 
     void applyYawOffset(double& q0, double& q1, double& q2, double& q3);
+    //! \brief Check whether ROS time has jumped back. If so, reset the filter.
+    void checkTimeJump();
 };
 
 #endif  // IMU_FILTER_IMU_MADWICK_FILTER_ROS_H

--- a/imu_filter_madgwick/src/imu_filter.cpp
+++ b/imu_filter_madgwick/src/imu_filter.cpp
@@ -352,3 +352,8 @@ void ImuFilter::getGravity(float& rx, float& ry, float& rz, float gravity)
             break;
     }
 }
+
+void ImuFilter::reset()
+{
+    setOrientation(1, 0, 0, 0);
+}

--- a/imu_filter_madgwick/test/madgwick_test.cpp
+++ b/imu_filter_madgwick/test/madgwick_test.cpp
@@ -25,6 +25,12 @@ void filterStationary(float Ax, float Ay, float Az, float Mx, float My,
     }
 
     filter.getOrientation(q0, q1, q2, q3);
+
+    // test resetting the filter
+    filter.reset();
+    double rq0, rq1, rq2, rq3;
+    filter.getOrientation(rq0, rq1, rq2, rq3);
+    ASSERT_QUAT_EQUAL(rq0, rq1, rq2, rq3, 1.0, 0.0, 0.0, 0.0);
 }
 
 template <WorldFrame::WorldFrame FRAME>
@@ -48,6 +54,12 @@ void filterStationary(float Ax, float Ay, float Az, double& q0, double& q1,
     }
 
     filter.getOrientation(q0, q1, q2, q3);
+
+    // test resetting the filter
+    filter.reset();
+    double rq0, rq1, rq2, rq3;
+    filter.getOrientation(rq0, rq1, rq2, rq3);
+    ASSERT_QUAT_EQUAL(rq0, rq1, rq2, rq3, 1.0, 0.0, 0.0, 0.0);
 }
 
 #define TEST_STATIONARY_ENU(in_am, exp_result)                                \


### PR DESCRIPTION
Fixes #164. Currently, the PR only supports resetting on jumps back. Default behavior is the same as tf2_listener: Reset whenever `ros::Time::now()` is lower than the previous recorded one. Parameter `~time_jump_threshold` can be used to specify that jumps smaller than the threshold do not result in resetting the filter (e.g. when running in real time and system clock jumps because of a time sync event). To disable the resetting behavior, set the threshold to `DURATION_MAX`.