### PR TITLE
WIP - CMakeListst - fix find_package

### DIFF
--- a/imu_complementary_filter/CMakeLists.txt
+++ b/imu_complementary_filter/CMakeLists.txt
@@ -28,6 +28,9 @@ add_library(complementary_filter
 )
 #target_link_libraries(complementary_filter rclcpp sensor_msgs)
 
+set_target_properties(complementary_filter PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+)
 
 # create complementary_filter_node executable
 add_executable(complementary_filter_node
@@ -38,11 +41,11 @@ ament_target_dependencies(complementary_filter geometry_msgs rclcpp message_filt
 
 install(TARGETS
         complementary_filter
-        DESTINATION lib/${PROJECT_NAME}
+        DESTINATION lib
 )
 install(TARGETS
         complementary_filter_node
-        DESTINATION lib/${PROJECT_NAME}
+        DESTINATION lib
 )
 
 ## Mark cpp header files for installation
@@ -56,6 +59,7 @@ install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
 
+ament_export_libraries(complementary_filter)
 ament_export_include_directories(include)
 ament_export_dependencies(geometry_msgs message_filters sensor_msgs std_msgs tf2 tf2_ros)
 ament_package()


### PR DESCRIPTION
Hi, 
I decided to introduce small improvements inside CMakeLists.txt:

1. _POSITION_INDEPENDENT_CODE_:
 external static library can be marked with POSITION_INDEPENDENT_CODE.
With this flag it can be used with dynamic libraries.
more details:
- https://stackoverflow.com/questions/38296756/what-is-the-idiomatic-way-in-cmake-to-add-the-fpic-compiler-option
- https://cmake.org/cmake/help/v3.16/guide/tutorial/index.html#mixing-static-and-shared-step-9

2. _find_package(imu_complementary_filter REQUIRED)_ related:
`DESTINATION lib/${PROJECT_NAME}`  outputs files to:
```
pb@L1HVS07:~/workspace/install/imu_complementary_filter$ tree lib/
lib/
├─imu_complementary_filter 
    |─ complementary_filter_node
    └── libcomplementary_filter.a
```

when `DESTINATION lib`  outputs files to directly to lib:
```
pb@L1HVS07:~/workspace/install/imu_complementary_filter$ tree lib/
lib/
├── complementary_filter_node
└── libcomplementary_filter.a
```