### PR TITLE
Update CMakeLists to use targets

### DIFF
--- a/imu_complementary_filter/CMakeLists.txt
+++ b/imu_complementary_filter/CMakeLists.txt
@@ -14,31 +14,43 @@ find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-
-include_directories(
-  include
-)
-
-## Declare a cpp library
 add_library(complementary_filter
   src/complementary_filter.cpp
   src/complementary_filter_ros.cpp
   include/imu_complementary_filter/complementary_filter.h
   include/imu_complementary_filter/complementary_filter_ros.h
 )
-#target_link_libraries(complementary_filter rclcpp sensor_msgs)
-
+target_compile_features(complementary_filter PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_include_directories(complementary_filter PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(complementary_filter
+  geometry_msgs
+  message_filters
+  rclcpp
+  sensor_msgs
+  std_msgs
+  tf2
+  tf2_ros
+)
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(complementary_filter PRIVATE "IMU_COMPLEMENTARY_FILTER_BUILDING_LIBRARY")
 
 # create complementary_filter_node executable
 add_executable(complementary_filter_node
   src/complementary_filter_node.cpp)
+target_include_directories(complementary_filter_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
 target_link_libraries(complementary_filter_node complementary_filter)
-ament_target_dependencies(complementary_filter geometry_msgs rclcpp message_filters sensor_msgs std_msgs tf2 tf2_ros)
-#ament_target_dependencies(complementary_filter_node)
 
-install(TARGETS
-        complementary_filter
-        DESTINATION lib/${PROJECT_NAME}
+install(
+  TARGETS complementary_filter
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 install(TARGETS
         complementary_filter_node
@@ -46,10 +58,9 @@ install(TARGETS
 )
 
 ## Mark cpp header files for installation
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME}
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
+install(
+  DIRECTORY include/
+  DESTINATION include
 )
 
 install(DIRECTORY launch
@@ -57,5 +68,8 @@ install(DIRECTORY launch
 )
 
 ament_export_include_directories(include)
-ament_export_dependencies(geometry_msgs message_filters sensor_msgs std_msgs tf2 tf2_ros)
+ament_export_libraries(complementary_filter)
+ament_export_targets(
+  export_${PROJECT_NAME}
+)
 ament_package()

--- a/imu_complementary_filter/CMakeLists.txt
+++ b/imu_complementary_filter/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-add_library(complementary_filter
+add_library(complementary_filter SHARED
   src/complementary_filter.cpp
   src/complementary_filter_ros.cpp
   include/imu_complementary_filter/complementary_filter.h

--- a/imu_filter_madgwick/CMakeLists.txt
+++ b/imu_filter_madgwick/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(imu_filter_madgwick)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
@@ -19,18 +14,20 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-include_directories(include)
-
 add_library(imu_filter_madgwick SHARED
             src/imu_filter.cpp
             src/imu_filter_ros.cpp
             src/stateless_orientation.cpp)
+target_compile_features(imu_filter_madgwick PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_include_directories(imu_filter_madgwick PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
 ament_target_dependencies(imu_filter_madgwick
+  geometry_msgs
   rclcpp
   rclcpp_components
-  std_msgs
   sensor_msgs
-  geometry_msgs
+  std_msgs
   tf2_geometry_msgs
   tf2_ros
 )
@@ -39,16 +36,17 @@ target_compile_definitions(imu_filter_madgwick
   PRIVATE "IMU_FILTER_MADGWICK_CPP_BUILDING_DLL")
 
 add_executable(imu_filter_madgwick_node src/imu_filter_node.cpp)
+target_include_directories(imu_filter_madgwick_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
 target_link_libraries(imu_filter_madgwick_node imu_filter_madgwick)
-ament_target_dependencies(imu_filter_madgwick_node
-  rclcpp)
 
-install(TARGETS
-  imu_filter_madgwick
+install(
+  TARGETS imu_filter_madgwick
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
 )
 
 install(
@@ -71,5 +69,8 @@ endif()
 
 ament_export_include_directories(include)
 ament_export_libraries(imu_filter_madgwick)
+ament_export_targets(
+  export_${PROJECT_NAME}
+)
 
 ament_package()


### PR DESCRIPTION
This is loosely based on the output of:

    ros2 pkg create --build-type ament_cmake --dependencies rclcpp --library-name foolib --node-name foonode foo