### PR TITLE
Set read-only parameters as read_only

### DIFF
--- a/imu_complementary_filter/src/complementary_filter_ros.cpp
+++ b/imu_complementary_filter/src/complementary_filter_ros.cpp
@@ -100,19 +100,26 @@ void ComplementaryFilterROS::initializeParams()
     bool do_adaptive_gain;
     double orientation_stddev;
 
-    fixed_frame_ = this->declare_parameter<std::string>("fixed_frame", "odom");
-    use_mag_ = this->declare_parameter<bool>("use_mag", false);
-    publish_tf_ = this->declare_parameter<bool>("publish_tf", false);
-    reverse_tf_ = this->declare_parameter<bool>("reverse_tf", false);
-    constant_dt_ = this->declare_parameter<double>("constant_dt", 0.0);
+    // set "Not Dynamically Reconfigurable Parameters"
+    rcl_interfaces::msg::ParameterDescriptor readonly;
+    readonly.read_only = true;
+    fixed_frame_ =
+        this->declare_parameter<std::string>("fixed_frame", "odom", readonly);
+    use_mag_ = this->declare_parameter<bool>("use_mag", false, readonly);
+    publish_tf_ = this->declare_parameter<bool>("publish_tf", false, readonly);
+    reverse_tf_ = this->declare_parameter<bool>("reverse_tf", false, readonly);
+    constant_dt_ =
+        this->declare_parameter<double>("constant_dt", 0.0, readonly);
     publish_debug_topics_ =
-        this->declare_parameter<bool>("publish_debug_topics", false);
-    gain_acc = this->declare_parameter<double>("gain_acc", 0.01);
-    gain_mag = this->declare_parameter<double>("gain_mag", 0.01);
+        this->declare_parameter<bool>("publish_debug_topics", false, readonly);
+    gain_acc = this->declare_parameter<double>("gain_acc", 0.01, readonly);
+    gain_mag = this->declare_parameter<double>("gain_mag", 0.01, readonly);
     do_bias_estimation =
-        this->declare_parameter<bool>("do_bias_estimation", true);
-    bias_alpha = this->declare_parameter<double>("bias_alpha", 0.01);
-    do_adaptive_gain = this->declare_parameter<bool>("do_adaptive_gain", true);
+        this->declare_parameter<bool>("do_bias_estimation", true, readonly);
+    bias_alpha = this->declare_parameter<double>("bias_alpha", 0.01, readonly);
+    do_adaptive_gain =
+        this->declare_parameter<bool>("do_adaptive_gain", true, readonly);
+
     orientation_stddev =
         this->declare_parameter<double>("orientation_stddev", 0.0);
     orientation_variance_ = orientation_stddev * orientation_stddev;

--- a/imu_complementary_filter/src/complementary_filter_ros.cpp
+++ b/imu_complementary_filter/src/complementary_filter_ros.cpp
@@ -101,24 +101,28 @@ void ComplementaryFilterROS::initializeParams()
     double orientation_stddev;
 
     // set "Not Dynamically Reconfigurable Parameters"
-    rcl_interfaces::msg::ParameterDescriptor readonly;
-    readonly.read_only = true;
+    auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+    descriptor.read_only = true;
+
     fixed_frame_ =
-        this->declare_parameter<std::string>("fixed_frame", "odom", readonly);
-    use_mag_ = this->declare_parameter<bool>("use_mag", false, readonly);
-    publish_tf_ = this->declare_parameter<bool>("publish_tf", false, readonly);
-    reverse_tf_ = this->declare_parameter<bool>("reverse_tf", false, readonly);
+        this->declare_parameter<std::string>("fixed_frame", "odom", descriptor);
+    use_mag_ = this->declare_parameter<bool>("use_mag", false, descriptor);
+    publish_tf_ =
+        this->declare_parameter<bool>("publish_tf", false, descriptor);
+    reverse_tf_ =
+        this->declare_parameter<bool>("reverse_tf", false, descriptor);
     constant_dt_ =
-        this->declare_parameter<double>("constant_dt", 0.0, readonly);
-    publish_debug_topics_ =
-        this->declare_parameter<bool>("publish_debug_topics", false, readonly);
-    gain_acc = this->declare_parameter<double>("gain_acc", 0.01, readonly);
-    gain_mag = this->declare_parameter<double>("gain_mag", 0.01, readonly);
+        this->declare_parameter<double>("constant_dt", 0.0, descriptor);
+    publish_debug_topics_ = this->declare_parameter<bool>(
+        "publish_debug_topics", false, descriptor);
+    gain_acc = this->declare_parameter<double>("gain_acc", 0.01, descriptor);
+    gain_mag = this->declare_parameter<double>("gain_mag", 0.01, descriptor);
     do_bias_estimation =
-        this->declare_parameter<bool>("do_bias_estimation", true, readonly);
-    bias_alpha = this->declare_parameter<double>("bias_alpha", 0.01, readonly);
+        this->declare_parameter<bool>("do_bias_estimation", true, descriptor);
+    bias_alpha =
+        this->declare_parameter<double>("bias_alpha", 0.01, descriptor);
     do_adaptive_gain =
-        this->declare_parameter<bool>("do_adaptive_gain", true, readonly);
+        this->declare_parameter<bool>("do_adaptive_gain", true, descriptor);
 
     orientation_stddev =
         this->declare_parameter<double>("orientation_stddev", 0.0);

--- a/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -41,22 +41,24 @@ ImuFilterMadgwickRos::ImuFilterMadgwickRos(const rclcpp::NodeOptions &options)
 {
     RCLCPP_INFO(get_logger(), "Starting ImuFilter");
 
-    // **** get paramters
-    declare_parameter("stateless", false);
+    // **** get parameters
+    auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+    descriptor.read_only = true;
+    declare_parameter("stateless", false, descriptor);
     get_parameter("stateless", stateless_);
-    declare_parameter("use_mag", true);
+    declare_parameter("use_mag", true, descriptor);
     get_parameter("use_mag", use_mag_);
-    declare_parameter("publish_tf", true);
+    declare_parameter("publish_tf", true, descriptor);
     get_parameter("publish_tf", publish_tf_);
-    declare_parameter("reverse_tf", false);
+    declare_parameter("reverse_tf", false, descriptor);
     get_parameter("reverse_tf", reverse_tf_);
-    declare_parameter("fixed_frame", "odom");
+    declare_parameter("fixed_frame", "odom", descriptor);
     get_parameter("fixed_frame", fixed_frame_);
-    declare_parameter("constant_dt", 0.0);
+    declare_parameter("constant_dt", 0.0, descriptor);
     get_parameter("constant_dt", constant_dt_);
-    declare_parameter("remove_gravity_vector", false);
+    declare_parameter("remove_gravity_vector", false, descriptor);
     get_parameter("remove_gravity_vector", remove_gravity_vector_);
-    declare_parameter("publish_debug_topics", false);
+    declare_parameter("publish_debug_topics", false, descriptor);
     get_parameter("publish_debug_topics", publish_debug_topics_);
 
     double yaw_offset = 0.0;
@@ -73,7 +75,7 @@ ImuFilterMadgwickRos::ImuFilterMadgwickRos(const rclcpp::NodeOptions &options)
         yaw_offset_total_);  // Create this quaternion for yaw offset (radians)
 
     std::string world_frame;
-    declare_parameter("world_frame", "enu");
+    declare_parameter("world_frame", "enu", descriptor);
     get_parameter("world_frame", world_frame);
     if (world_frame == "ned")
     {

--- a/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -62,10 +62,10 @@ ImuFilterMadgwickRos::ImuFilterMadgwickRos(const rclcpp::NodeOptions &options)
     get_parameter("publish_debug_topics", publish_debug_topics_);
 
     double yaw_offset = 0.0;
-    declare_parameter("yaw_offset", 0.0);
+    declare_parameter("yaw_offset", 0.0, descriptor);
     get_parameter("yaw_offset", yaw_offset);
     double declination = 0.0;
-    declare_parameter("declination", 0.0);
+    declare_parameter("declination", 0.0, descriptor);
     get_parameter("declination", declination);
 
     // create yaw offset quaternion


### PR DESCRIPTION
I just tried to tune the filter with rqt_reconfigure while it was running without success, until I realized that the parameters are not dynamically reconfigurable.

I propose setting them as read-only with `declare_parameter`.

`yaw_offset` and `declination` is [not documented](http://wiki.ros.org/imu_filter_madgwick), but without further search I guess they are read-only too?