### PR TITLE
Show remapped topic names

### DIFF
--- a/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -543,15 +543,14 @@ void ImuFilterMadgwickRos::reconfigCallback(
 void ImuFilterMadgwickRos::checkTopicsTimerCallback()
 {
     if (use_mag_)
-        RCLCPP_WARN_STREAM(
-            get_logger(),
-            "Still waiting for data on topics "
-            << imu_subscriber_->getTopic() << "and "
-            << mag_subscriber_->getTopic() << "...");
-    else
         RCLCPP_WARN_STREAM(get_logger(),
-                           "Still waiting for data on topic "
-                           << imu_subscriber_->getTopic() << "...");
+                           "Still waiting for data on topics "
+                               << imu_subscriber_->getTopic() << "and "
+                               << mag_subscriber_->getTopic() << "...");
+    else
+        RCLCPP_WARN_STREAM(get_logger(), "Still waiting for data on topic "
+                                             << imu_subscriber_->getTopic()
+                                             << "...");
 }
 
 #include "rclcpp_components/register_node_macro.hpp"

--- a/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -545,7 +545,7 @@ void ImuFilterMadgwickRos::checkTopicsTimerCallback()
     if (use_mag_)
         RCLCPP_WARN_STREAM(get_logger(),
                            "Still waiting for data on topics "
-                               << imu_subscriber_->getTopic() << "and "
+                               << imu_subscriber_->getTopic() << " and "
                                << mag_subscriber_->getTopic() << "...");
     else
         RCLCPP_WARN_STREAM(get_logger(), "Still waiting for data on topic "

--- a/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -545,10 +545,13 @@ void ImuFilterMadgwickRos::checkTopicsTimerCallback()
     if (use_mag_)
         RCLCPP_WARN_STREAM(
             get_logger(),
-            "Still waiting for data on topics /imu/data_raw and /imu/mag...");
+            "Still waiting for data on topics "
+            << imu_subscriber_->getTopic() << "and "
+            << mag_subscriber_->getTopic() << "...");
     else
         RCLCPP_WARN_STREAM(get_logger(),
-                           "Still waiting for data on topic /imu/data_raw...");
+                           "Still waiting for data on topic "
+                           << imu_subscriber_->getTopic() << "...");
 }
 
 #include "rclcpp_components/register_node_macro.hpp"


### PR DESCRIPTION
This PR, similar to #192, changes the topic names in the warning message to remapped ones in order to make the message more understandable.

