### PR TITLE
Use pipx to install pre-commit in github actions

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,9 +13,10 @@ jobs:
     - name: Install apt dependencies
       run: |
         apt-get update
-        apt-get install -y build-essential clang-format file git python3-pip python3-colcon-common-extensions python3-rosdep
+        apt-get install -y build-essential clang-format file git python3-pip python3-colcon-common-extensions python3-rosdep pipx
     - name: Install pip dependencies
-      run: pip install pre-commit
+      run: |
+        pipx run pipx --global install pre-commit
     - name: Checkout repository
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Recently, due to the switch of the Ubuntu distribution from jassy to noble for rolling(https://discourse.ros.org/t/preparing-ros-2-rolling-for-the-transition-to-ubuntu-24-04/35673), pip install now throws errors like the following
https://github.com/CCNYRoboticsLab/imu_tools/actions/runs/8841107418/job/24277648791
```bash
Run pip install pre-commit
WARNING: The directory '/github/home/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/CCNYRoboticsLab/imu_tools/actions/runs/8841107418/job/24277648791?pr=196#step:4:7)68 for the detailed specification.
Error: Process completed with exit code 1.
```

Since the error message suggests using `pipx`, this PR changed to install pre-commit using `pipx`.
Unfortunately as the `pipx` installed via apt package doesn't support the `--global` option, we use `pipx run` to execute the latest `pipx`.