### PR TITLE
CI: Use pre-commit from apt repositories instead of pip

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,9 +13,7 @@ jobs:
     - name: Install apt dependencies
       run: |
         apt-get update
-        apt-get install -y build-essential clang-format file git python3-pip python3-colcon-common-extensions python3-rosdep
-    - name: Install pip dependencies
-      run: pip install pre-commit
+        apt-get install -y build-essential clang-format file git python3-pip python3-colcon-common-extensions python3-rosdep pre-commit
     - name: Checkout repository
       uses: actions/checkout@v3
       with:

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ pre-commit formatting checks
 
 This repo has a [pre-commit](https://pre-commit.com/) check that runs in CI.
 You can use this locally and set it up to run automatically before you commit
-something. To install, use pip:
+something. To install, use apt:
 
 ```bash
-pip3 install --user pre-commit
+sudo apt install pre-commit
 ```
 
 To run over all the files in the repo manually:


### PR DESCRIPTION
pre-commit is available as an APT package starting with Ubuntu 22.04.

This commit avoids the following error:

    WARNING: The directory '/github/home/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
    error: externally-managed-environment

    x This environment is externally managed
    --> To install Python packages system-wide, try apt install
        python3-xyz, where xyz is the package you are trying to
        install.

        If you wish to install a non-Debian-packaged Python package,
        create a virtual environment using python3 -m venv path/to/venv.
        Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
        sure you have python3-full installed.

        If you wish to install a non-Debian packaged Python application,
        it may be easiest to use pipx install xyz, which will manage a
        virtual environment for you. Make sure you have pipx installed.

        See /usr/share/doc/python3.12/README.venv for more information.

    note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
    hint: See PEP 668 for the detailed specification.