### PR TITLE
Split humble/iron/jazzy from rolling

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rosdistro: [humble, iron, jazzy, rolling]
+        rosdistro: [humble, iron, jazzy]
       fail-fast: false
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
* removed rolling from the CI config
* this is in preparation of fixing the deprecated header warnings in
rolling, which is backward-incompatible, so splitting the branches is
the only way (see #207 for discussion)
* from now on, the 2.2.* releases will go to `rolling` and the 2.1.* releases to the other branches.