### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/imu_complementary_filter/CMakeLists.txt
+++ b/imu_complementary_filter/CMakeLists.txt
@@ -25,13 +25,14 @@ target_include_directories(complementary_filter PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(complementary_filter PUBLIC
-  geometry_msgs
-  message_filters
-  rclcpp
-  sensor_msgs
-  std_msgs
-  tf2
-  tf2_ros
+  ${geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  message_filters::message_filters
+  rclcpp::rclcpp
+  sensor_msgs::sensor_msgs_library
+  tf2::tf2
+  tf2_ros::tf2_ros
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/imu_complementary_filter/CMakeLists.txt
+++ b/imu_complementary_filter/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_features(complementary_filter PUBLIC c_std_99 cxx_std_17)  # Requ
 target_include_directories(complementary_filter PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(complementary_filter
+target_link_libraries(complementary_filter PUBLIC
   geometry_msgs
   message_filters
   rclcpp

--- a/imu_filter_madgwick/CMakeLists.txt
+++ b/imu_filter_madgwick/CMakeLists.txt
@@ -22,7 +22,7 @@ target_compile_features(imu_filter_madgwick PUBLIC c_std_99 cxx_std_17)  # Requi
 target_include_directories(imu_filter_madgwick PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(imu_filter_madgwick
+target_link_libraries(imu_filter_madgwick PUBLIC
   geometry_msgs
   rclcpp
   rclcpp_components

--- a/imu_filter_madgwick/CMakeLists.txt
+++ b/imu_filter_madgwick/CMakeLists.txt
@@ -23,13 +23,15 @@ target_include_directories(imu_filter_madgwick PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(imu_filter_madgwick PUBLIC
-  geometry_msgs
-  rclcpp
-  rclcpp_components
-  sensor_msgs
-  std_msgs
-  tf2_geometry_msgs
-  tf2_ros
+  ${geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  sensor_msgs::sensor_msgs_library
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
 )
 rclcpp_components_register_nodes(imu_filter_madgwick "ImuFilterMadgwickRos")
 target_compile_definitions(imu_filter_madgwick

--- a/rviz_imu_plugin/CMakeLists.txt
+++ b/rviz_imu_plugin/CMakeLists.txt
@@ -61,7 +61,8 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 ## the ``find_package(Qt4 ...)`` line above, or by the
 ## ``set(QT_LIBRARIES Qt5::Widgets)``, and with whatever libraries
 ## catkin has included.
-target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies} rviz_ogre_vendor::OgreMain rviz_ogre_vendor::OgreOverlay Qt5::Widgets)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC rviz_ogre_vendor::OgreMain rviz_ogre_vendor::OgreOverlay Qt5::Widgets ${sensor_msgs_TARGETS} message_filters::message_filters rviz_common::rviz_common rviz_ogre_vendor::OgreMain rviz_rendering::rviz_rendering sensor_msgs::sensor_msgs_library tf2::tf2 tf2_ros::tf2_ros)
 
 # prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")

--- a/rviz_imu_plugin/CMakeLists.txt
+++ b/rviz_imu_plugin/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 ## the ``find_package(Qt4 ...)`` line above, or by the
 ## ``set(QT_LIBRARIES Qt5::Widgets)``, and with whatever libraries
 ## catkin has included.
-ament_target_dependencies(${PROJECT_NAME} PUBLIC ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC rviz_ogre_vendor::OgreMain rviz_ogre_vendor::OgreOverlay Qt5::Widgets)
 

--- a/rviz_imu_plugin/CMakeLists.txt
+++ b/rviz_imu_plugin/CMakeLists.txt
@@ -61,9 +61,7 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 ## the ``find_package(Qt4 ...)`` line above, or by the
 ## ``set(QT_LIBRARIES Qt5::Widgets)``, and with whatever libraries
 ## catkin has included.
-target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
-
-target_link_libraries(${PROJECT_NAME} PUBLIC rviz_ogre_vendor::OgreMain rviz_ogre_vendor::OgreOverlay Qt5::Widgets)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies} rviz_ogre_vendor::OgreMain rviz_ogre_vendor::OgreOverlay Qt5::Widgets)
 
 # prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
