### PR TITLE
CI: Update checkout action to v5

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -30,7 +30,7 @@ jobs:
         apt-get update
         apt-get install -y build-essential clang-format file git python3-pip python3-colcon-common-extensions python3-rosdep pre-commit
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: src/imu_tools
     - name: Use rosdep to install remaining dependencies


### PR DESCRIPTION
This fixes the deprecation warning for Node v20.