### PR TITLE
Fix build failures in update methods

### DIFF
--- a/rviz_imu_plugin/src/imu_display.cpp
+++ b/rviz_imu_plugin/src/imu_display.cpp
@@ -113,7 +113,7 @@ void ImuDisplay::reset()
     acc_visual_->hide();
 }
 
-void ImuDisplay::update(float /* dt */, float /* ros_dt */)
+void ImuDisplay::update(std::chrono::nanoseconds /* wall_dt */, std::chrono::nanoseconds /* ros_dt */)
 {
     updateTop();
     updateBox();

--- a/rviz_imu_plugin/src/imu_display.h
+++ b/rviz_imu_plugin/src/imu_display.h
@@ -69,7 +69,7 @@ class ImuDisplay
 
     void reset() override;
 
-    void update(float dt, float ros_dt) override;
+    void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   private:
     void createProperties();

--- a/rviz_imu_plugin/src/mag_display.cpp
+++ b/rviz_imu_plugin/src/mag_display.cpp
@@ -85,7 +85,7 @@ void MagDisplay::reset()
     mag_visual_->hide();
 }
 
-void MagDisplay::update(float /* dt */, float /* ros_dt */)
+void MagDisplay::update(std::chrono::nanoseconds /* wall_dt */, std::chrono::nanoseconds /* ros_dt */)
 {
     updateMag();
 }

--- a/rviz_imu_plugin/src/mag_display.h
+++ b/rviz_imu_plugin/src/mag_display.h
@@ -67,7 +67,7 @@ class MagDisplay
 
     void reset() override;
 
-    void update(float dt, float ros_dt) override;
+    void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   private:
     void createProperties();


### PR DESCRIPTION
This fixes build errors like the following:

    In file included from /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.3-1/src/imu_display.cpp:31:
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.3-1/src/imu_display.h:72:10: error: 'void rviz_imu_plugin::ImuDisplay::update(float, float)' marked 'override', but does not override
       72 |     void update(float dt, float ros_dt) override;
          |          ^~~~~~

The `update(float, float)` method was replaced with `update(std::chrono::duration, std::chrono::duration)` in https://github.com/ros2/rviz/pull/1533.