### PR TITLE
Use SPDX license tags in package.xml

### DIFF
--- a/imu_complementary_filter/package.xml
+++ b/imu_complementary_filter/package.xml
@@ -5,7 +5,7 @@
   <description>Filter which fuses angular velocities, accelerations, and (optionally) magnetic readings from a generic IMU device into a quaternion to represent the orientation of the device wrt the global frame. Based on the algorithm by Roberto G. Valenti etal. described in the paper "Keeping a Good Attitude: A Quaternion-Based Orientation Filter for IMUs and MARGs" available at http://www.mdpi.com/1424-8220/15/8/19302 .</description>
 
   <maintainer email="martin.guenther@dfki.de">Martin Günther</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url>http://www.mdpi.com/1424-8220/15/8/19302</url>
   <author email="robertogl.valenti@gmail.com">Roberto G. Valenti</author>

--- a/imu_filter_madgwick/package.xml
+++ b/imu_filter_madgwick/package.xml
@@ -6,7 +6,7 @@
   <description>
   Filter which fuses angular velocities, accelerations, and (optionally) magnetic readings from a generic IMU device into an orientation. Based on code by Sebastian Madgwick, http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms.
   </description>
-  <license>GPL</license>
+  <license>GPL-3.0-or-later</license>
   <url>http://ros.org/wiki/imu_filter_madgwick</url>
   <author email="ivan.dryanovski@gmail.com">Ivan Dryanovski</author>
   <maintainer email="martin.guenther@dfki.de">Martin Günther</maintainer>

--- a/imu_tools/package.xml
+++ b/imu_tools/package.xml
@@ -5,7 +5,8 @@
     Various tools for IMU devices
   </description>
   <maintainer email="martin.guenther@dfki.de">Martin Günther</maintainer>
-  <license>BSD, GPL</license>
+  <license>BSD-3-Clause</license>
+  <license>GPL-3.0-or-later</license>
 
   <url>http://ros.org/wiki/imu_tools</url>
 

--- a/rviz_imu_plugin/package.xml
+++ b/rviz_imu_plugin/package.xml
@@ -6,7 +6,7 @@
   <description>
     RVIZ plugin for IMU visualization
   </description>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url>http://ros.org/wiki/rviz_imu_plugin</url>
   <author email="ivan.dryanovski@gmail.com">Ivan Dryanovski</author>
   <maintainer email="martin.guenther@dfki.de">Martin Günther</maintainer>


### PR DESCRIPTION
This silences few warnings reported by [ros_license_toolkit](https://github.com/boschresearch/ros_license_toolkit).