### PR TITLE
Add missing includes

### DIFF
--- a/rviz_imu_plugin/src/imu_display.cpp
+++ b/rviz_imu_plugin/src/imu_display.cpp
@@ -32,6 +32,9 @@
 
 #include <rviz_common/properties/status_property.hpp>
 #include <rviz_common/logging.hpp>
+#include <OgreSceneNode.h>
+#include <OgreSceneManager.h>
+
 namespace rviz_imu_plugin {
 
 ImuDisplay::ImuDisplay()

--- a/rviz_imu_plugin/src/mag_display.cpp
+++ b/rviz_imu_plugin/src/mag_display.cpp
@@ -32,6 +32,8 @@
 
 #include <rviz_common/properties/status_property.hpp>
 #include <rviz_common/logging.hpp>
+#include <OgreSceneNode.h>
+#include <OgreSceneManager.h>
 
 namespace rviz_imu_plugin {
 


### PR DESCRIPTION
Without these, I get the following build errors in latest rolling:

    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/imu_display.cpp: In member function 'virtual void rviz_imu_plugin::ImuDisplay::onEnable()':
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/imu_display.cpp:67:16: error: invalid use of incomplete type 'class Ogre::SceneNode'
       67 |     scene_node_->setVisible(true);
          |                ^~
    In file included from /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/imu_display.h:37,
                     from /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/imu_display.cpp:31:
    /nix/store/h70jr156g5i17ppcyhfhpvrrxf7zs0li-ros-rolling-rviz-common-16.0.3-r1/include/rviz_common/rviz_common/display.hpp:52:7: note: forward declaration of 'class Ogre::SceneNode'
       52 | class SceneNode;
          |       ^~~~~~~~~
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/imu_display.cpp: In member function 'virtual void rviz_imu_plugin::ImuDisplay::onDisable()':
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/imu_display.cpp:78:16: error: invalid use of incomplete type 'class Ogre::SceneNode'
       78 |     scene_node_->setVisible(false);
          |                ^~
    /nix/store/h70jr156g5i17ppcyhfhpvrrxf7zs0li-ros-rolling-rviz-common-16.0.3-r1/include/rviz_common/rviz_common/display.hpp:52:7: note: forward declaration of 'class Ogre::SceneNode'
       52 | class SceneNode;
          |       ^~~~~~~~~
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/imu_display.cpp: In member function 'virtual void rviz_imu_plugin::ImuDisplay::onInitialize()':
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/imu_display.cpp:86:33: error: invalid use of incomplete type 'class Ogre::SceneManager'
       86 |     scene_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode();
          |                                 ^~
    /nix/store/h70jr156g5i17ppcyhfhpvrrxf7zs0li-ros-rolling-rviz-common-16.0.3-r1/include/rviz_common/rviz_common/display.hpp:51:7: note: forward declaration of 'class Ogre::SceneManager'
       51 | class SceneManager;
          |       ^~~~~~~~~~~~
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/imu_display.cpp:98:16: error: invalid use of incomplete type 'class Ogre::SceneNode'
       98 |     scene_node_->setVisible(isEnabled());
          |                ^~
    /nix/store/h70jr156g5i17ppcyhfhpvrrxf7zs0li-ros-rolling-rviz-common-16.0.3-r1/include/rviz_common/rviz_common/display.hpp:52:7: note: forward declaration of 'class Ogre::SceneNode'
       52 | class SceneNode;
          |       ^~~~~~~~~
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/mag_display.cpp: In member function 'virtual void rviz_imu_plugin::MagDisplay::onEnable()':
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/mag_display.cpp:50:16: error: invalid use of incomplete type 'class Ogre::SceneNode'
       50 |     scene_node_->setVisible(true);
          |                ^~
    In file included from /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/mag_display.h:37,
                     from /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/mag_display.cpp:31:
    /nix/store/h70jr156g5i17ppcyhfhpvrrxf7zs0li-ros-rolling-rviz-common-16.0.3-r1/include/rviz_common/rviz_common/display.hpp:52:7: note: forward declaration of 'class Ogre::SceneNode'
       52 | class SceneNode;
          |       ^~~~~~~~~
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/mag_display.cpp: In member function 'virtual void rviz_imu_plugin::MagDisplay::onDisable()':
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/mag_display.cpp:59:16: error: invalid use of incomplete type 'class Ogre::SceneNode'
       59 |     scene_node_->setVisible(false);
          |                ^~
    /nix/store/h70jr156g5i17ppcyhfhpvrrxf7zs0li-ros-rolling-rviz-common-16.0.3-r1/include/rviz_common/rviz_common/display.hpp:52:7: note: forward declaration of 'class Ogre::SceneNode'
       52 | class SceneNode;
          |       ^~~~~~~~~
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/mag_display.cpp: In member function 'virtual void rviz_imu_plugin::MagDisplay::onInitialize()':
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/mag_display.cpp:67:33: error: invalid use of incomplete type 'class Ogre::SceneManager'
       67 |     scene_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode();
          |                                 ^~
    /nix/store/h70jr156g5i17ppcyhfhpvrrxf7zs0li-ros-rolling-rviz-common-16.0.3-r1/include/rviz_common/rviz_common/display.hpp:51:7: note: forward declaration of 'class Ogre::SceneManager'
       51 | class SceneManager;
          |       ^~~~~~~~~~~~
    /build/imu_tools-release-release-rolling-rviz_imu_plugin-2.2.4-2/src/mag_display.cpp:72:16: error: invalid use of incomplete type 'class Ogre::SceneNode'
       72 |     scene_node_->setVisible(isEnabled());
          |                ^~
    /nix/store/h70jr156g5i17ppcyhfhpvrrxf7zs0li-ros-rolling-rviz-common-16.0.3-r1/include/rviz_common/rviz_common/display.hpp:52:7: note: forward declaration of 'class Ogre::SceneNode'
       52 | class SceneNode;
          |       ^~~~~~~~~