### PR TITLE
CI: fix pre-commit failures on Python 3.14 / clang-format 21

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -47,7 +47,7 @@ repos:
         exclude: *excludes
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 26.5.1
     hooks:
       - id: black
 

--- a/imu_complementary_filter/src/complementary_filter_node.cpp
+++ b/imu_complementary_filter/src/complementary_filter_node.cpp
@@ -33,7 +33,7 @@
 
 #include "imu_complementary_filter/complementary_filter_ros.h"
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     rclcpp::init(argc, argv);
     auto filter = std::make_shared<imu_tools::ComplementaryFilterROS>();

--- a/imu_complementary_filter/src/complementary_filter_ros.cpp
+++ b/imu_complementary_filter/src/complementary_filter_ros.cpp
@@ -182,9 +182,9 @@ void ComplementaryFilterROS::imuCallback(ImuMsg::ConstSharedPtr imu_msg_raw)
 {
     checkTimeJump();
 
-    const geometry_msgs::msg::Vector3 &a = imu_msg_raw->linear_acceleration;
-    const geometry_msgs::msg::Vector3 &w = imu_msg_raw->angular_velocity;
-    const rclcpp::Time &time = imu_msg_raw->header.stamp;
+    const geometry_msgs::msg::Vector3& a = imu_msg_raw->linear_acceleration;
+    const geometry_msgs::msg::Vector3& w = imu_msg_raw->angular_velocity;
+    const rclcpp::Time& time = imu_msg_raw->header.stamp;
 
     // Initialize.
     if (!initialized_filter_)
@@ -215,10 +215,10 @@ void ComplementaryFilterROS::imuMagCallback(ImuMsg::ConstSharedPtr imu_msg_raw,
 {
     checkTimeJump();
 
-    const geometry_msgs::msg::Vector3 &a = imu_msg_raw->linear_acceleration;
-    const geometry_msgs::msg::Vector3 &w = imu_msg_raw->angular_velocity;
-    const geometry_msgs::msg::Vector3 &m = mag_msg->magnetic_field;
-    const rclcpp::Time &time = imu_msg_raw->header.stamp;
+    const geometry_msgs::msg::Vector3& a = imu_msg_raw->linear_acceleration;
+    const geometry_msgs::msg::Vector3& w = imu_msg_raw->angular_velocity;
+    const geometry_msgs::msg::Vector3& m = mag_msg->magnetic_field;
+    const rclcpp::Time& time = imu_msg_raw->header.stamp;
 
     // Initialize.
     if (!initialized_filter_)

--- a/imu_filter_madgwick/include/imu_filter_madgwick/base_node.hpp
+++ b/imu_filter_madgwick/include/imu_filter_madgwick/base_node.hpp
@@ -7,7 +7,7 @@ namespace imu_filter {
 class BaseNode : public rclcpp::Node
 {
   public:
-    explicit BaseNode(std::string name, const rclcpp::NodeOptions &options)
+    explicit BaseNode(std::string name, const rclcpp::NodeOptions& options)
         : Node(name, options)
     {
     }
@@ -26,10 +26,10 @@ class BaseNode : public rclcpp::Node
 
     // Declare a parameter that has no integer or floating point range
     // constraints
-    void add_parameter(const std::string &name,
-                       const rclcpp::ParameterValue &default_value,
-                       const std::string &description = "",
-                       const std::string &additional_constraints = "",
+    void add_parameter(const std::string& name,
+                       const rclcpp::ParameterValue& default_value,
+                       const std::string& description = "",
+                       const std::string& additional_constraints = "",
                        bool read_only = false)
     {
         auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
@@ -43,11 +43,11 @@ class BaseNode : public rclcpp::Node
     }
 
     // Declare a parameter that has a floating point range constraint
-    void add_parameter(const std::string &name,
-                       const rclcpp::ParameterValue &default_value,
+    void add_parameter(const std::string& name,
+                       const rclcpp::ParameterValue& default_value,
                        const floating_point_range fp_range,
-                       const std::string &description = "",
-                       const std::string &additional_constraints = "",
+                       const std::string& description = "",
+                       const std::string& additional_constraints = "",
                        bool read_only = false)
     {
         auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
@@ -65,11 +65,11 @@ class BaseNode : public rclcpp::Node
     }
 
     // Declare a parameter that has an integer range constraint
-    void add_parameter(const std::string &name,
-                       const rclcpp::ParameterValue &default_value,
+    void add_parameter(const std::string& name,
+                       const rclcpp::ParameterValue& default_value,
                        const integer_range int_range,
-                       const std::string &description = "",
-                       const std::string &additional_constraints = "",
+                       const std::string& description = "",
+                       const std::string& additional_constraints = "",
                        bool read_only = false)
     {
         auto descriptor = rcl_interfaces::msg::ParameterDescriptor();

--- a/imu_filter_madgwick/src/imu_filter_node.cpp
+++ b/imu_filter_madgwick/src/imu_filter_node.cpp
@@ -25,7 +25,7 @@
 
 #include "imu_filter_madgwick/imu_filter_ros.h"
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     rclcpp::init(argc, argv);
 

--- a/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -34,7 +34,7 @@ using namespace std::chrono_literals;
 using namespace rclcpp;
 using namespace std::placeholders;
 
-ImuFilterMadgwickRos::ImuFilterMadgwickRos(const rclcpp::NodeOptions &options)
+ImuFilterMadgwickRos::ImuFilterMadgwickRos(const rclcpp::NodeOptions& options)
     : BaseNode("imu_filter_madgwick", options),
       tf_broadcaster_(*this),
       tf_buffer_(this->get_clock()),
@@ -238,8 +238,8 @@ void ImuFilterMadgwickRos::imuCallback(ImuMsg::ConstSharedPtr imu_msg_raw)
 
     std::lock_guard<std::mutex> lock(mutex_);
 
-    const geometry_msgs::msg::Vector3 &ang_vel = imu_msg_raw->angular_velocity;
-    const geometry_msgs::msg::Vector3 &lin_acc =
+    const geometry_msgs::msg::Vector3& ang_vel = imu_msg_raw->angular_velocity;
+    const geometry_msgs::msg::Vector3& lin_acc =
         imu_msg_raw->linear_acceleration;
 
     rclcpp::Clock steady_clock(RCL_STEADY_TIME);  // for throttle logger message
@@ -305,10 +305,10 @@ void ImuFilterMadgwickRos::imuMagCallback(ImuMsg::ConstSharedPtr imu_msg_raw,
 
     std::lock_guard<std::mutex> lock(mutex_);
 
-    const geometry_msgs::msg::Vector3 &ang_vel = imu_msg_raw->angular_velocity;
-    const geometry_msgs::msg::Vector3 &lin_acc =
+    const geometry_msgs::msg::Vector3& ang_vel = imu_msg_raw->angular_velocity;
+    const geometry_msgs::msg::Vector3& lin_acc =
         imu_msg_raw->linear_acceleration;
-    const geometry_msgs::msg::Vector3 &mag_fld = mag_msg->magnetic_field;
+    const geometry_msgs::msg::Vector3& mag_fld = mag_msg->magnetic_field;
 
     rclcpp::Time time = imu_msg_raw->header.stamp;
     imu_frame_ = imu_msg_raw->header.frame_id;
@@ -438,8 +438,8 @@ void ImuFilterMadgwickRos::publishTransform(ImuMsg::ConstSharedPtr imu_msg_raw)
  * @param q2 quaternion z component
  * @param q3 quaternion w component
  **/
-void ImuFilterMadgwickRos::applyYawOffset(double &q0, double &q1, double &q2,
-                                          double &q3)
+void ImuFilterMadgwickRos::applyYawOffset(double& q0, double& q1, double& q2,
+                                          double& q3)
 {
     if (yaw_offset_total_ != 0.0)
     {
@@ -503,7 +503,7 @@ void ImuFilterMadgwickRos::publishFilteredMsg(
     }
 }
 
-void ImuFilterMadgwickRos::publishOrientationFiltered(const ImuMsg &imu_msg)
+void ImuFilterMadgwickRos::publishOrientationFiltered(const ImuMsg& imu_msg)
 {
     geometry_msgs::msg::PoseStamped pose;
     pose.header.stamp = imu_msg.header.stamp;
@@ -517,7 +517,7 @@ void ImuFilterMadgwickRos::publishOrientationFiltered(const ImuMsg &imu_msg)
         transform = tf_buffer_.lookupTransform(
             fixed_frame_, imu_msg.header.frame_id, imu_msg.header.stamp,
             rclcpp::Duration::from_seconds(0.1));
-    } catch (tf2::TransformException &ex)
+    } catch (tf2::TransformException& ex)
     {
         RCLCPP_WARN(
             this->get_logger(), "Could not get transform from %s to %s: %s",
@@ -532,7 +532,7 @@ void ImuFilterMadgwickRos::publishOrientationFiltered(const ImuMsg &imu_msg)
     orientation_filtered_publisher_->publish(pose);
 }
 
-void ImuFilterMadgwickRos::publishRawMsg(const rclcpp::Time &t, float roll,
+void ImuFilterMadgwickRos::publishRawMsg(const rclcpp::Time& t, float roll,
                                          float pitch, float yaw)
 {
     geometry_msgs::msg::Vector3Stamped rpy;
@@ -545,16 +545,16 @@ void ImuFilterMadgwickRos::publishRawMsg(const rclcpp::Time &t, float roll,
 }
 
 void ImuFilterMadgwickRos::postSetParametersCallback(
-    const std::vector<rclcpp::Parameter> &parameters)
+    const std::vector<rclcpp::Parameter>& parameters)
 {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    for (const auto &changed_parameter : parameters)
+    for (const auto& changed_parameter : parameters)
     {
         if (changed_parameter.get_type() == ParameterType::PARAMETER_DOUBLE)
         {
-            const auto &name = changed_parameter.get_name();
-            const auto &value = changed_parameter.get_value<double>();
+            const auto& name = changed_parameter.get_name();
+            const auto& value = changed_parameter.get_value<double>();
             RCLCPP_INFO(get_logger(), "Parameter %s set to %f", name.c_str(),
                         value);
             if (name == "gain")

--- a/rviz_imu_plugin/src/imu_display.cpp
+++ b/rviz_imu_plugin/src/imu_display.cpp
@@ -113,7 +113,8 @@ void ImuDisplay::reset()
     acc_visual_->hide();
 }
 
-void ImuDisplay::update(std::chrono::nanoseconds /* wall_dt */, std::chrono::nanoseconds /* ros_dt */)
+void ImuDisplay::update(std::chrono::nanoseconds /* wall_dt */,
+                        std::chrono::nanoseconds /* ros_dt */)
 {
     updateTop();
     updateBox();

--- a/rviz_imu_plugin/src/imu_display.h
+++ b/rviz_imu_plugin/src/imu_display.h
@@ -69,7 +69,8 @@ class ImuDisplay
 
     void reset() override;
 
-    void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
+    void update(std::chrono::nanoseconds wall_dt,
+                std::chrono::nanoseconds ros_dt) override;
 
   private:
     void createProperties();

--- a/rviz_imu_plugin/src/mag_display.cpp
+++ b/rviz_imu_plugin/src/mag_display.cpp
@@ -85,7 +85,8 @@ void MagDisplay::reset()
     mag_visual_->hide();
 }
 
-void MagDisplay::update(std::chrono::nanoseconds /* wall_dt */, std::chrono::nanoseconds /* ros_dt */)
+void MagDisplay::update(std::chrono::nanoseconds /* wall_dt */,
+                        std::chrono::nanoseconds /* ros_dt */)
 {
     updateMag();
 }

--- a/rviz_imu_plugin/src/mag_display.h
+++ b/rviz_imu_plugin/src/mag_display.h
@@ -67,7 +67,8 @@ class MagDisplay
 
     void reset() override;
 
-    void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
+    void update(std::chrono::nanoseconds wall_dt,
+                std::chrono::nanoseconds ros_dt) override;
 
   private:
     void createProperties();


### PR DESCRIPTION
- bump pre-commit-hooks v4.1.0 -> v6.0.0 (removes deprecated stage names warning)
- bump black 22.3.0 -> 26.5.1 (22.3.0 crashes on Python 3.14 with 'RuntimeError: There is no current event loop' in reformat_many)
- reformat 9 C++ files with clang-format 21 as used in the CI container (Google-based .clang-format now wants 'char** argv' / 'const Foo& a' and wraps >80-col signatures)

Verified with a local replica of the CI job: pre-commit run -a passes inside ros:rolling-ros-core (Python 3.14.4, clang-format 21.1.8).